### PR TITLE
Package up cloudflare sentry into an astro integration

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -6,13 +6,7 @@ import cloudflare from "@astrojs/cloudflare";
 import { normalizeFrontmatter } from "./packages/my-remark";
 import { remarkObsidian } from "./packages/remark-obsidian";
 import mdRenderer from "./packages/astro-md";
-import { sentryVitePlugin } from "@sentry/vite-plugin";
-
-/**
- * This is a little hack to be able to progrmmatically detect
- * if we're pre-rendering or in SSR mode.
- */
-process.env.IS_BUILD = "true";
+import astroCloudflareSentry from "./packages/astro-cf-sentry";
 
 // https://astro.build/config
 export default defineConfig({
@@ -24,32 +18,19 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [normalizeFrontmatter, remarkObsidian],
   },
-  integrations: [mdRenderer(), tailwind()],
+  integrations: [
+    mdRenderer(),
+    tailwind(),
+    astroCloudflareSentry({
+      org: "just-be",
+      project: "just-be-dev",
+      telemetry: false,
+    }),
+  ],
   adapter: cloudflare({
     imageService: "cloudflare",
     platformProxy: {
       enabled: true,
     },
   }),
-  vite: {
-    build: {
-      sourcemap: true,
-    },
-    ssr: {
-      external: ["node:async_hooks"],
-    },
-    plugins: [
-      sentryVitePlugin({
-        /**
-         * CF_PAGES set by Cloudflare at build time
-         * @see https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables
-         */
-        disable: !process.env.CF_PAGES,
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: "just-be",
-        project: "just-be-dev",
-        telemetry: false,
-      }),
-    ],
-  },
 });

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "@astrojs/check": "^0.9.1",
     "@astrojs/cloudflare": "^11.0.4",
     "@astrojs/tailwind": "^5.1.0",
-    "@sentry/cloudflare": "^8.25.0",
-    "@sentry/vite-plugin": "^2.22.0",
     "astro": "^4.13.1",
     "hono": "^4.5.4",
     "tailwindcss": "^3.4.7",

--- a/packages/astro-cf-sentry/index.ts
+++ b/packages/astro-cf-sentry/index.ts
@@ -1,0 +1,49 @@
+import type { AstroIntegration } from "astro";
+import {
+  type SentryVitePluginOptions,
+  sentryVitePlugin,
+} from "@sentry/vite-plugin";
+
+interface Options extends SentryVitePluginOptions {}
+
+export default function astroCloudflareSentry(
+  options: Options
+): AstroIntegration {
+  return {
+    name: "astro:cf-sentry",
+    hooks: {
+      async "astro:config:setup"({ addMiddleware, updateConfig }) {
+        /**
+         * This is a little hack to be able to progrmmatically detect
+         * if we're pre-rendering or in SSR mode.
+         */
+        process.env.IS_BUILD = "true";
+        addMiddleware({
+          entrypoint: "@just-be/astro-cf-sentry/middleware.ts",
+          order: "pre",
+        });
+        updateConfig({
+          vite: {
+            build: {
+              sourcemap: true,
+            },
+            ssr: {
+              external: ["node:async_hooks"],
+            },
+            plugins: [
+              sentryVitePlugin({
+                /**
+                 * CF_PAGES set by Cloudflare at build time
+                 * @see https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables
+                 */
+                disable: !process.env.CF_PAGES,
+                authToken: process.env.SENTRY_AUTH_TOKEN,
+                ...options,
+              }),
+            ],
+          },
+        });
+      },
+    },
+  };
+}

--- a/packages/astro-cf-sentry/middleware.ts
+++ b/packages/astro-cf-sentry/middleware.ts
@@ -1,4 +1,4 @@
-/// <reference types="./env.d.ts" />
+/// <reference types="../../src/env.d.ts" />
 
 import * as Sentry from "@sentry/cloudflare";
 import { defineMiddleware } from "astro:middleware";

--- a/packages/astro-cf-sentry/package.json
+++ b/packages/astro-cf-sentry/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@just-be/astro-cf-sentry",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "Justin Bennett <oss@just-be.dev>",
+  "license": "MIT",
+  "dependencies": {
+    "@sentry/cloudflare": "^8.25.0",
+    "@sentry/vite-plugin": "^2.22.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@astrojs/markdown-remark':
-      specifier: ^5.2.0
-      version: 5.2.0
-
 patchedDependencies:
   '@astrojs/markdown-remark':
     hash: v5kacvnx7x7h7wln5itqdcnhza
@@ -28,12 +22,6 @@ importers:
       '@astrojs/tailwind':
         specifier: ^5.1.0
         version: 5.1.0(astro@4.13.1(@types/node@22.1.0)(typescript@5.5.4))(tailwindcss@3.4.7)
-      '@sentry/cloudflare':
-        specifier: ^8.25.0
-        version: 8.25.0
-      '@sentry/vite-plugin':
-        specifier: ^2.22.0
-        version: 2.22.0
       astro:
         specifier: ^4.13.1
         version: 4.13.1(@types/node@22.1.0)(typescript@5.5.4)
@@ -59,6 +47,15 @@ importers:
       wrangler:
         specifier: 3.70.0
         version: 3.70.0(@cloudflare/workers-types@4.20240729.0)
+
+  packages/astro-cf-sentry:
+    dependencies:
+      '@sentry/cloudflare':
+        specifier: ^8.25.0
+        version: 8.25.0
+      '@sentry/vite-plugin':
+        specifier: ^2.22.0
+        version: 2.22.0
 
   packages/astro-md:
     dependencies:


### PR DESCRIPTION
Factors out the code added in #12 into a separate astro integration. Anyone reading this is welcome to pull it out into their own codebase. I'm working towards a publishable monorepo, but I'm just not there yet and it's not super high priority for me right now so it'd be better to just copy/paste the code. 

If you need any, let me know and I'd be happy to assist. 

The biggest drawback to having this in an integration right now is the same story for _all_ astro integrations. There's no way that I've found to be able to pass parameters into a middleware. Quite annoying, but here we are. 