### PR TITLE
Implement vanity URLs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,10 @@ import astroCloudflareSentry from "./packages/astro-cf-sentry";
 
 // https://astro.build/config
 export default defineConfig({
+  site:
+    process.env.NODE_ENV === "development"
+      ? "http://localhost:4321"
+      : "https://just-be.dev",
   /**
    * Note: I'd like this to be hybrid, but when that's enabled cf deployments give me a 500 error
    * @see https://just-be.sentry.io/share/issue/ab09f9239b3f45d1b27a222743afd6aa/

--- a/packages/remark-obsidian/wiki-link/utils.ts
+++ b/packages/remark-obsidian/wiki-link/utils.ts
@@ -1,6 +1,6 @@
 import type { WikiLinkNode } from "./types";
 
-export const slugify = (s: string) => s.toLowerCase().replace(/\s+/g, "_");
+export const slugify = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 
 export const displayName = (wikiLink: WikiLinkNode) => {
   let displayName = wikiLink.alias ?? wikiLink.value ?? "";

--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -3,9 +3,10 @@ import "../style.css";
 
 interface Props {
   title: string;
+  id: string
 }
 
-const { title } = Astro.props;
+const { id, title } = Astro.props;
 ---
 
 <!doctype html>
@@ -15,6 +16,7 @@ const { title } = Astro.props;
     <meta name="description" content="Astro description" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="canonical" href=`${Astro.site}${id}`/>
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
   </head>

--- a/src/layouts/default.astro
+++ b/src/layouts/default.astro
@@ -3,13 +3,14 @@ import BaseLayout from "./base.astro";
 import Header from "@components/Header.astro";
 
 interface Props {
+  id: string;
   title: string;
 }
 
-const { title } = Astro.props;
+const { id, title } = Astro.props;
 ---
 
-<BaseLayout title={title}>
+<BaseLayout id={id} title={title}>
   <main class="lg-:container mx-auto px-6 py-2 max-w-screen-lg">
     <Header />
     <article class="prose lg:prose-xl">

--- a/src/layouts/homepage.astro
+++ b/src/layouts/homepage.astro
@@ -3,13 +3,14 @@ import BaseLayout from "./base.astro";
 import Header from "@components/Header.astro";
 
 interface Props {
+  id: string;
   title: string;
 }
 
-const { title } = Astro.props;
+const { id, title } = Astro.props;
 ---
 
-<BaseLayout title={title}>
+<BaseLayout id={id} title={title}>
   <main class="lg-:container mx-auto px-6 py-2 max-w-screen-lg">
     <Header />
     <article class="prose lg:prose-xl">

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,8 +1,10 @@
 ---
-// import { getEntry } from "astro:content";
-
 export const prerender = false;
 
+// This matches to the note in my obsidian setup
+// that's homepage. I probably could avoid hard coding this
+// by having a mapping in the KV store, but this is
+// simpler for now. 
 const HOME_SLUG = "01J4CPMJ91NF1DNQPE3TZ50HH0";
 
 const ulidRegex = /^[0-9A-HJ-NP-TV-Z]{26}$/i;
@@ -12,11 +14,10 @@ function isULID(ulid: string) {
 }
 
 let { slug } = Astro.params;
+
 // default to homepage slug
 slug ??= HOME_SLUG;
 
-
-console.log('slug?', slug)
 
 let html = "";
 let layout = "default";
@@ -36,11 +37,11 @@ if (isULID(slug)) {
   layout = metadata.frontmatter.layout.slice(9, -6);
 } 
 
-console.log('slug', slug) 
-console.log('html', html)
-
 if (!html) return Astro.rewrite("/404");
 
+// The slug is used to determine the canonical URL. For every page that _isn't_ the hope page I want that
+// to the the ULID. For the home page, I just want the root URL to be canonical. 
+slug = slug === HOME_SLUG ? "" : slug;
 
 const Layout = (await import(`../layouts/${layout}.astro`)).default;
 ---

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -15,10 +15,18 @@ let { slug } = Astro.params;
 // default to homepage slug
 slug ??= HOME_SLUG;
 
+
+console.log('slug?', slug)
+
 let html = "";
 let layout = "default";
 
-if (!html && isULID(slug)) {
+if (!isULID(slug)) {
+  slug = await Astro.locals.runtime.env.KV_MAPPINGS.get(slug) as string;
+  if (!slug) return Astro.rewrite("/404");
+}
+
+if (isULID(slug)) {
   const content = await Astro.locals.runtime.env.R2_BUCKET.get(slug);
   if (!content) return Astro.rewrite("/404");
   const { code, metadata } = await Astro.locals.render(await content.text());
@@ -26,15 +34,17 @@ if (!html && isULID(slug)) {
   // The slice here is a hack to remove the "@layouts/" and ".astro" from the layout name
   // so that the import below works correctly
   layout = metadata.frontmatter.layout.slice(9, -6);
-}
+} 
 
-if (!html) {
-  return Astro.rewrite("/404");
-}
+console.log('slug', slug) 
+console.log('html', html)
+
+if (!html) return Astro.rewrite("/404");
+
 
 const Layout = (await import(`../layouts/${layout}.astro`)).default;
 ---
 
-<Layout>
+<Layout id={slug}>
   <Fragment set:html={html} />
 </Layout>

--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -7,7 +7,7 @@ import type { APIContext, APIRoute } from "astro";
 import { bearerAuth } from "hono/bearer-auth";
 import { etag } from "hono/etag";
 
-export const prerender = false;
+const slugify = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 
 // Dump cf env in top level of context
 type AstroContext = APIContext & APIContext["locals"]["runtime"]["env"];
@@ -24,12 +24,17 @@ const app = new Hono<{ Bindings: AstroContext }>()
   .post("/publish/:id", async (c) => {
     const id = c.req.param("id");
     const props: Record<string, any> = c.req.query();
-    if (props.slugs) {
-      const slugs = props.slugs.split(/[\s,]+/).filter(Boolean);
+    // Alises (as stored in obsidian) are treated as slugs for navigation
+    if (props.aliases) {
+      const slugs: string[] = props.aliases
+        .split(",")
+        .filter(Boolean)
+        .map(slugify);
       await Promise.all(
-        slugs.map((slug: string) =>
+        slugs.map((slug) =>
           c.env.KV_MAPPINGS.get(slug).then((currentId) => {
             if (currentId) {
+              // Mappings are immutable. If a slug is already mapped to a different id, throw an error.
               if (currentId !== id) {
                 throw new Error(`Slug ${slug} is mapped to ${currentId}`);
               }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,0 @@
-/// <reference types="vitest" />
-import { getViteConfig } from "astro/config";
-
-export default getViteConfig({
-  test: {},
-});


### PR DESCRIPTION
In my obsidian setup I have all my notes named as ULIDs. I essentially translate those over into top level URLS `https://just-be.dev/<ulid>` that I treat as the canonical for every page but the homepage. ULIDs aren't the easiest on the eyes though, so it would be nice to have something more human readable. One thing that's _extremely_ important to me though, is to never break URLs. 

In this PR, during the publishing process (`POST /api/publish/:ulid`) I'm grabbing all the frontmatter off as query parameters. I extract the aliases, slugify them, and store them in cloudflare's KV. When a request comes through any non-ulid URLs hit cloudflares KV first. 