### PR TITLE
Fix header being wrong color

### DIFF
--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -20,7 +20,7 @@ const { id, title } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
   </head>
-  <body class="prose m-auto">
+  <body class="m-auto">
     <slot />
   </body>
 </html>


### PR DESCRIPTION
Made a slight mistake where I added `prose` (from tailwind-typography) to the body which caused my header to be the wrong color. 