### PR TITLE
Reload when notes change in dev

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -7,6 +7,7 @@ import { normalizeFrontmatter } from "./packages/my-remark";
 import { remarkObsidian } from "./packages/remark-obsidian";
 import mdRenderer from "./packages/astro-md";
 import astroCloudflareSentry from "./packages/astro-cf-sentry";
+import fullReload from "vite-plugin-full-reload";
 
 // https://astro.build/config
 export default defineConfig({
@@ -37,4 +38,7 @@ export default defineConfig({
       enabled: true,
     },
   }),
+  vite: {
+    plugins: [fullReload(["notes/**/*.md"])],
+  },
 });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240729.0",
     "@tailwindcss/typography": "^0.5.14",
+    "vite-plugin-full-reload": "^1.2.0",
     "vitest": "^2.0.5",
     "wrangler": "3.70.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@astrojs/markdown-remark':
+      specifier: ^5.2.0
+      version: 5.2.0
+
 patchedDependencies:
   '@astrojs/markdown-remark':
     hash: v5kacvnx7x7h7wln5itqdcnhza
@@ -41,6 +47,9 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.14
         version: 0.5.14(tailwindcss@3.4.7)
+      vite-plugin-full-reload:
+        specifier: ^1.2.0
+        version: 1.2.0
       vitest:
         specifier: ^2.0.5
         version: 2.0.5(@types/node@22.1.0)
@@ -2806,6 +2815,9 @@ packages:
     resolution: {integrity: sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
+
+  vite-plugin-full-reload@1.2.0:
+    resolution: {integrity: sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==}
 
   vite@5.3.5:
     resolution: {integrity: sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==}
@@ -6048,6 +6060,11 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vite-plugin-full-reload@1.2.0:
+    dependencies:
+      picocolors: 1.0.1
+      picomatch: 2.3.1
 
   vite@5.3.5(@types/node@22.1.0):
     dependencies:

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,4 +1,6 @@
 ---
+import { a } from "vitest/dist/chunks/suite.CcK46U-P.js";
+
 export const prerender = false;
 
 // This matches to the note in my obsidian setup
@@ -28,9 +30,17 @@ if (!isULID(slug)) {
 }
 
 if (isULID(slug)) {
-  const content = await Astro.locals.runtime.env.R2_BUCKET.get(slug);
+  let content = "";
+  if (process.env.NODE_ENV === "development") {
+    const fs = await import("node:fs/promises");
+    content = await fs.readFile(`./notes/${slug}.md`, "utf-8")
+  } else {
+    const result = await Astro.locals.runtime.env.R2_BUCKET.get(slug);
+    if (!result) return Astro.rewrite("/404");
+    content = await result.text();
+  }
   if (!content) return Astro.rewrite("/404");
-  const { code, metadata } = await Astro.locals.render(await content.text());
+  const { code, metadata } = await Astro.locals.render(content);
   html = code;
   // The slice here is a hack to remove the "@layouts/" and ".astro" from the layout name
   // so that the import below works correctly

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,6 +1,4 @@
 ---
-import { a } from "vitest/dist/chunks/suite.CcK46U-P.js";
-
 export const prerender = false;
 
 // This matches to the note in my obsidian setup

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -29,9 +29,13 @@ if (!isULID(slug)) {
 
 if (isULID(slug)) {
   let content = "";
+
+  // In dev read note from symlinked directory
   if (process.env.NODE_ENV === "development") {
     const fs = await import("node:fs/promises");
     content = await fs.readFile(`./notes/${slug}.md`, "utf-8")
+
+  // In prod pull from R2
   } else {
     const result = await Astro.locals.runtime.env.R2_BUCKET.get(slug);
     if (!result) return Astro.rewrite("/404");


### PR DESCRIPTION
My previous dev workflow was updating my publishing script to point at localhost, typing <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>p</kbd> in obsidian (to trigger the publish), and then refreshing the page. It's a bit slow when iterating on something locally. I updated the dev flow to have it just directly read files from the fs and added `vite-plugin-full-reload` to have it refresh the page when one of the notes are updated. 