### PR TITLE
support log files as years

### DIFF
--- a/scripts/ob.ts
+++ b/scripts/ob.ts
@@ -27,10 +27,10 @@ const rename = new Command()
   .action(async (_, path) => {
     const file = basename(path, ".md");
     const dir = dirname(path);
-    const targetDir = "Daily Notes";
-    if (/\d{4}-\d{2}-\d{2}/.test(file)) {
+    const targetDir = "logs";
+    if (/\d{4}/.test(file)) {
       if (dir.endsWith(targetDir)) return;
-      const targetFile = join(dir, targetDir, `${ulid()}.md`);
+      const targetFile = join(dir, targetDir, `${file}.md`);
       await move(path, targetFile, {
         overwrite: false,
       });


### PR DESCRIPTION
Instead of the traditional obsidian daily notes setup, I want to have files that are based on year and stored in the `logs` directory. So `logs/2024.md` would represent this year. Any notes that I take would just be grouped inside there under headings for their day (e.g. `## 08-22` would be today's heading). New entries are added to the top so the logs read in reverse chronological order. 