### PR TITLE
fix(style): adjust gradient color in blockquote

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -35,7 +35,7 @@ h2 + p > sup {
 }
 
 blockquote {
-  @apply !border-slate-400 bg-gradient-to-r from-slate-300 to-slate-50 !px-6 py-0.5;
+  @apply !border-slate-400 bg-gradient-to-r from-slate-300 to-gray-50 !px-6 py-0.5;
 }
 
 blockquote ul {


### PR DESCRIPTION
Change `blockquote` background gradient to transition from `slate-300`
to `gray-50` for improved color consistency.