### PR TITLE
add asset publishing

### DIFF
--- a/scripts/ob.ts
+++ b/scripts/ob.ts
@@ -91,6 +91,7 @@ async function publishAsset(path: string) {
       method: "POST",
       headers: {
         "Content-Type": contentType(path) || "application/octet-stream",
+        Authorization: `Bearer ${Deno.env.get("PUBLISH_KEY")}`,
       },
       body: await Deno.readFile(path),
     }

--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -9,6 +9,9 @@ import { etag } from "hono/etag";
 
 const slugify = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 
+const isValidSha256 = (hashString: string) =>
+  /^[a-fA-F0-9]{64}$/.test(hashString);
+
 // Dump cf env in top level of context
 type AstroContext = APIContext & APIContext["locals"]["runtime"]["env"];
 
@@ -20,8 +23,8 @@ const app = new Hono<{ Bindings: AstroContext }>()
     }
     return bearerAuth({ token: c.env.PUBLISH_KEY })(c, next);
   })
-  .use("/publish/*", etag())
-  .post("/publish/:id", async (c) => {
+  .use(etag())
+  .post("/notes/:id", async (c) => {
     const id = c.req.param("id");
     const props: Record<string, any> = c.req.query();
     // Alises (as stored in obsidian) are treated as slugs for navigation
@@ -49,6 +52,24 @@ const app = new Hono<{ Bindings: AstroContext }>()
       onlyIf: { etagDoesNotMatch: c.req.header("If-None-Match") },
     });
     if (!result) return c.json({ error: "Failed to upload" }, 500);
+    const { size, version, httpEtag: etag } = result;
+    return c.json({ ok: true, size, version }, 200, { etag });
+  })
+  .post("/assets/:filePath", async (c) => {
+    const filePath = c.req.param("filePath");
+    const fileName = filePath.split(".")[0];
+    if (!isValidSha256(fileName)) {
+      return c.json({ error: "Invalid file name: File must be SHA256" }, 400);
+    }
+    const result = await c.env.R2_ASSETS.put(filePath, await c.req.blob(), {
+      onlyIf: { etagDoesNotMatch: c.req.header("If-None-Match") },
+    });
+    if (!result) return c.json({ error: "Failed to upload" }, 500);
+
+    if (!("body" in result)) {
+      return c.status(304);
+    }
+
     const { size, version, httpEtag: etag } = result;
     return c.json({ ok: true, size, version }, 200, { etag });
   });

--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -5,7 +5,7 @@
 import { Hono } from "hono";
 import type { APIContext, APIRoute } from "astro";
 import { bearerAuth } from "hono/bearer-auth";
-import { isValidSha256 } from "~/utils";
+import { isValidSha256, slugify } from "~/utils";
 
 // Dump cf env in top level of context
 type AstroContext = APIContext & APIContext["locals"]["runtime"]["env"];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,4 @@
+export const slugify = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
+
+export const isValidSha256 = (hashString: string) =>
+  /^[a-fA-F0-9]{64}$/.test(hashString);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
       "baseUrl": ".",
       "paths": {
-        "~/*": ["./*"],
+        "~/*": ["./src/*"],
         "@components/*": ["src/components/*"],
         "@layouts/*": ["src/layouts/*"],
         "@just-be/*": ["packages/*"],


### PR DESCRIPTION
Updates the publishing process to support publishing assets as well as notes. I decided to change the API. Previously I had `POST /api/publish` which isn't very restful and I don't actually want one endpoint to handle all the publishing. I updated this to `POST /api/notes` for notes publishing and `POST /api/assets` for assets publishing. I could theoretically add GET endpoints too to retrieve (or list) the assets/notes. 

Requests for assets are made to `/assets`. If it's a SHA256 shaped file it'll try to pull that directly from R2. If it's anything else it'll check KV to see if a mapping has been added before pulling it down. When in development I just skip the whole KV/R2 dance and grab the file directly from the filesystem. 

The last remaining bit before I can actually use this is implementing the obsidian embeds in my `remark-obsidian` package. That'll be for another PR though. 