### PR TITLE
Create CI for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Vitest
+        run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,13 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run Vitest
-        run: npm run test
+        run: pnpm run test

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "type": "module",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "hono": "^4.5.4",
     "mime": "^4.0.4",
     "tailwindcss": "^3.4.7",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vite-tsconfig-paths": "^5.0.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240729.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
+    "test": "vitest",
     "build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "version": "0.0.1",
   "engines": {
-    "node": ">=22"
+    "node": "20.16.0"
   },
   "scripts": {
     "dev": "astro dev",

--- a/packages/remark-obsidian/embed/embed.test.ts
+++ b/packages/remark-obsidian/embed/embed.test.ts
@@ -12,10 +12,7 @@ test("![[Internal Link]]", () => {
     htmlExtensions: [html()],
   });
 
-  assert.equal(
-    serialized,
-    '<p><embed inline-content src="Internal Link" /></p>'
-  );
+  assert.equal(serialized, '<p><object data="/internal-link"></object></p>');
 });
 
 test("![[Internal Link.pdf]]", () => {
@@ -26,7 +23,7 @@ test("![[Internal Link.pdf]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed src="Internal Link.pdf" type="application/pdf" /></p>'
+    '<p><object data="/assets/internal-link.pdf" type="application/pdf"></object></p>'
   );
 });
 
@@ -38,7 +35,7 @@ test("![[Internal Link.pdf#width=100&height=200]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed src="Internal Link.pdf" type="application/pdf" width="100" height="200" /></p>'
+    '<p><object data="/assets/internal-link.pdf" type="application/pdf" width="100" height="200"></object></p>'
   );
 });
 
@@ -50,7 +47,7 @@ test("![[Internal Link.pdf#page=5]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed src="Internal Link.pdf" type="application/pdf" page="5" /></p>'
+    '<p><object data="/assets/internal-link.pdf" type="application/pdf" page="5"></object></p>'
   );
 });
 
@@ -62,7 +59,7 @@ test("![[Internal Link.pdf#page=5&zoom=2]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed src="Internal Link.pdf" type="application/pdf" page="5" zoom="2" /></p>'
+    '<p><object data="/assets/internal-link.pdf" type="application/pdf" page="5" zoom="2"></object></p>'
   );
 });
 
@@ -74,7 +71,7 @@ test("![[Internal Link.jpg]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed src="Internal Link.jpg" type="image/jpeg" /></p>'
+    '<p><object data="/assets/internal-link.jpg" type="image/jpeg"></object></p>'
   );
 });
 
@@ -86,7 +83,7 @@ test("![[Internal Link.mp3]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed src="Internal Link.mp3" type="audio/mpeg" /></p>'
+    '<p><object data="/assets/internal-link.mp3" type="audio/mpeg"></object></p>'
   );
 });
 
@@ -98,7 +95,7 @@ test("![[Internal Link.mp4]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed src="Internal Link.mp4" type="video/mp4" /></p>'
+    '<p><object data="/assets/internal-link.mp4" type="video/mp4"></object></p>'
   );
 });
 
@@ -110,7 +107,7 @@ test("![[Internal Link#Section]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed inline-content src="Internal Link#Section" /></p>'
+    '<p><object data="/internal-link#section"></object></p>'
   );
 });
 
@@ -122,6 +119,6 @@ test("![[Internal Link#^block-id]]", () => {
 
   assert.equal(
     serialized,
-    '<p><embed inline-content src="Internal Link#block-id" /></p>'
+    '<p><object data="/internal-link#block-id"></object></p>'
   );
 });

--- a/packages/remark-obsidian/embed/html.ts
+++ b/packages/remark-obsidian/embed/html.ts
@@ -3,7 +3,7 @@
 import type { CompileData, Handle, HtmlExtension } from "micromark-util-types";
 import mime from "mime";
 import { safeTpl } from "../parser-utils";
-import { slugify } from "../internal-link/utils";
+import { slugify } from "~/utils";
 
 export function html(): HtmlExtension {
   const enterEmbed: Handle = function () {
@@ -71,13 +71,10 @@ export function html(): HtmlExtension {
         ? `#${embed.headings.at(-1)}`
         : "";
 
-      this.tag(`<object data="${embed.value}${anchor}"></object>`);
+      this.tag(
+        `<object data="/${slugify(embed.value)}${slugify(anchor)}"></object>`
+      );
       return;
-    }
-
-    console.log("extension?", embed.extension);
-    if (embed.extension) {
-      embed.value = `/assets/${slugify(embed.value)}`;
     }
 
     if (embed.extension === "pdf") {
@@ -85,22 +82,22 @@ export function html(): HtmlExtension {
         embed.pdfParams &&
         Object.entries(embed.pdfParams)
           .map(([key, value]: [string, unknown]) => `${key}="${value}"`)
-          .join(" ") + " ";
+          .join(" ");
       this.tag(
-        `<object data="/assets/${embed.value}" type="application/pdf" ${
-          params ?? ""
-        }></object>`
+        `<object data="/assets/${slugify(
+          embed.value
+        )}" type="application/pdf"${safeTpl` ${params}`}></object>`
       );
       return;
     }
 
-    const width = safeTpl`width="${embed.dimensions?.[0]}" `;
+    const width = safeTpl` width="${embed.dimensions?.[0]}" `;
     const height = safeTpl`height="${embed.dimensions?.[1]}" `;
 
     this.tag(
-      `<object src="/assets/${embed.value}" type="${mime.getType(
+      `<object data="/assets/${slugify(embed.value)}" type="${mime.getType(
         embed.extension
-      )}" ${width}${height}/>`
+      )}"${width}${height}></object>`
     );
   };
 

--- a/packages/remark-obsidian/internal-link/internal-link.test.ts
+++ b/packages/remark-obsidian/internal-link/internal-link.test.ts
@@ -83,7 +83,7 @@ test("[[Internal Link#^Abc123]]", () => {
 
   assert.equal(
     serialized,
-    '<p><a href="/internal-link#^abc123">Internal Link > ^Abc123</a></p>'
+    '<p><a href="/internal-link#abc123">Internal Link > ^Abc123</a></p>'
   );
 });
 
@@ -93,7 +93,7 @@ test("[[Internal Link#^Abc123|Alias]]", () => {
     htmlExtensions: [html()],
   });
 
-  assert.equal(serialized, '<p><a href="/internal-link#^abc123">Alias</a></p>');
+  assert.equal(serialized, '<p><a href="/internal-link#abc123">Alias</a></p>');
 });
 
 test("[[#Main Section]]", () => {
@@ -102,7 +102,7 @@ test("[[#Main Section]]", () => {
     htmlExtensions: [html()],
   });
 
-  assert.equal(serialized, '<p><a href="/#main-section">Main Section</a></p>');
+  assert.equal(serialized, '<p><a href="#main-section">Main Section</a></p>');
 });
 
 test("[[#Main Section|Alias]]", () => {
@@ -111,7 +111,7 @@ test("[[#Main Section|Alias]]", () => {
     htmlExtensions: [html()],
   });
 
-  assert.equal(serialized, '<p><a href="/#main-section">Alias</a></p>');
+  assert.equal(serialized, '<p><a href="#main-section">Alias</a></p>');
 });
 
 test("[[#Main Section#Sub Section]]", () => {
@@ -122,7 +122,7 @@ test("[[#Main Section#Sub Section]]", () => {
 
   assert.equal(
     serialized,
-    '<p><a href="/#main-section#sub-section">Main Section > Sub Section</a></p>'
+    '<p><a href="#main-section#sub-section">Main Section > Sub Section</a></p>'
   );
 });
 
@@ -134,7 +134,7 @@ test("[[#Main Section#Sub Section|Alias]]", () => {
 
   assert.equal(
     serialized,
-    '<p><a href="/#main-section#sub-section">Alias</a></p>'
+    '<p><a href="#main-section#sub-section">Alias</a></p>'
   );
 });
 
@@ -144,7 +144,7 @@ test("[[#^Abc123]]", () => {
     htmlExtensions: [html()],
   });
 
-  assert.equal(serialized, '<p><a href="/#^abc123">^Abc123</a></p>');
+  assert.equal(serialized, '<p><a href="#abc123">^Abc123</a></p>');
 });
 
 test("[[#^Abc123|Alias]]", () => {
@@ -153,5 +153,5 @@ test("[[#^Abc123|Alias]]", () => {
     htmlExtensions: [html()],
   });
 
-  assert.equal(serialized, '<p><a href="/#^abc123">Alias</a></p>');
+  assert.equal(serialized, '<p><a href="#abc123">Alias</a></p>');
 });

--- a/packages/remark-obsidian/internal-link/utils.ts
+++ b/packages/remark-obsidian/internal-link/utils.ts
@@ -1,6 +1,7 @@
+import { slugify } from "~/utils";
 import type { InternalLinkNode } from "../types";
 
-export const slugify = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
+export { slugify } from "~/utils";
 
 export const displayName = (internalLink: InternalLinkNode) => {
   let displayName = internalLink.alias ?? internalLink.value ?? "";
@@ -29,6 +30,6 @@ export const href = (
   return slugify(
     internalLink.value
       ? `/${internalLink.value}${blockOrHeadings}`
-      : `/${blockOrHeadings}`
+      : `${blockOrHeadings}`
   );
 };

--- a/packages/remark-obsidian/remark-obsidian.test.ts
+++ b/packages/remark-obsidian/remark-obsidian.test.ts
@@ -49,40 +49,40 @@ test("[[Internal Links#Main Section#Sub Section|Alias]]", async () => {
 test("[[Internal Links#^Abc-123]]", async () => {
   const { code } = await md.render("[[Internal Links#^Abc-123]]");
   expect(code).toContain(
-    '<a href="/internal-links#^abc-123">Internal Links > ^Abc-123</a>'
+    '<a href="/internal-links#abc-123">Internal Links > ^Abc-123</a>'
   );
 });
 
 test("[[Internal Links#^Abc-123|Alias]]", async () => {
   const { code } = await md.render("[[Internal Links#^Abc-123|Alias]]");
-  expect(code).toContain('<a href="/internal-links#^abc-123">Alias</a>');
+  expect(code).toContain('<a href="/internal-links#abc-123">Alias</a>');
 });
 
 test("[[#Main Section]]", async () => {
   const { code } = await md.render("[[#Main Section]]");
-  expect(code).toContain('<a href="/#main-section">Main Section</a>');
+  expect(code).toContain('<a href="#main-section">Main Section</a>');
 });
 
 test("[[#Main Section|Alias]]", async () => {
   const { code } = await md.render("[[#Main Section|Alias]]");
-  expect(code).toContain('<a href="/#main-section">Alias</a>');
+  expect(code).toContain('<a href="#main-section">Alias</a>');
 });
 
 test("[[#Main Section#Sub Section]]", async () => {
   const { code } = await md.render("[[#Main Section#Sub Section]]");
   expect(code).toContain(
-    '<a href="/#main-section#sub-section">Main Section > Sub Section</a>'
+    '<a href="#main-section#sub-section">Main Section > Sub Section</a>'
   );
 });
 
 test("[[#^Abc-123]]", async () => {
   const { code } = await md.render("[[#^Abc-123]]");
-  expect(code).toContain('<a href="/#^abc-123">^Abc-123</a>');
+  expect(code).toContain('<a href="#abc-123">^Abc-123</a>');
 });
 
 test("[[#^Abc-123|Alias]]", async () => {
   const { code } = await md.render("[[#^Abc-123|Alias]]");
-  expect(code).toContain('<a href="/#^abc-123">Alias</a>');
+  expect(code).toContain('<a href="#abc-123">Alias</a>');
 });
 
 // New embed tests
@@ -219,13 +219,13 @@ test("![[Internal Link#Section|Alias]]", async () => {
 test("![[Internal Link#^block-id]]", async () => {
   const { code } = await md.render("![[Internal Link#^block-id]]");
   expect(code).toContain(
-    '<p><object data="/internal-link#^block-id"></object></p>'
+    '<p><object data="/internal-link#block-id"></object></p>'
   );
 });
 
 test("![[Internal Link#^block-id|Alias]]", async () => {
   const { code } = await md.render("![[Internal Link#^block-id|Alias]]");
   expect(code).toContain(
-    '<p><object data="/internal-link#^block-id" title="Alias"></object></p>'
+    '<p><object data="/internal-link#block-id" title="Alias"></object></p>'
   );
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
+      vite-tsconfig-paths:
+        specifier: ^5.0.1
+        version: 5.0.1(typescript@5.5.4)(vite@5.3.5(@types/node@22.1.0))
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240729.0
@@ -2835,6 +2838,14 @@ packages:
 
   vite-plugin-full-reload@1.2.0:
     resolution: {integrity: sha512-kz18NW79x0IHbxRSHm0jttP4zoO9P9gXh+n6UTwlNKnviTTEpOlum6oS9SmecrTtSr+muHEn5TUuC75UovQzcA==}
+
+  vite-tsconfig-paths@5.0.1:
+    resolution: {integrity: sha512-yqwv+LstU7NwPeNqajZzLEBVpUFU6Dugtb2P84FXuvaoYA+/70l9MHE+GYfYAycVyPSDYZ7mjOFuYBRqlEpTig==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@5.3.5:
     resolution: {integrity: sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==}
@@ -6089,6 +6100,17 @@ snapshots:
     dependencies:
       picocolors: 1.0.1
       picomatch: 2.3.1
+
+  vite-tsconfig-paths@5.0.1(typescript@5.5.4)(vite@5.3.5(@types/node@22.1.0)):
+    dependencies:
+      debug: 4.3.6
+      globrex: 0.1.2
+      tsconfck: 3.1.1(typescript@5.5.4)
+    optionalDependencies:
+      vite: 5.3.5(@types/node@22.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@5.3.5(@types/node@22.1.0):
     dependencies:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,8 @@
-export const slugify = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
+export const slugify = (s: string) =>
+  s
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-#\/\.]/g, "");
 
 export const isValidSha256 = (hashString: string) =>
   /^[a-fA-F0-9]{64}$/.test(hashString);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    // Add any additional test configurations here if needed
+  },
+});


### PR DESCRIPTION
Adds a simple GitHub action to run vitest tests on PRs. I've got tests for most of the markdown parsing and its good to ensure PRs don't accidentally break that. I had to add a package so that vitest could find ts-config (fix [documented here](https://vitest.dev/guide/common-errors.html#cannot-find-module-relative-path)).

I did make some minor test updates here too, just to get things in line with how I'd like to see them in prod. 