### PR TITLE
Temporarily move description

### DIFF
--- a/src/layouts/base.astro
+++ b/src/layouts/base.astro
@@ -14,7 +14,7 @@ const { id, title } = Astro.props;
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="description" content="Astro description" />
+    <!-- <meta name="description" content="Astro description" /> -->
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <link rel="canonical" href=`${Astro.site}${id}` />


### PR DESCRIPTION
The description is a hard coded string which isn't useful. Just drop it for now.