### PR TITLE
Replace all URLs with their canonical version

### DIFF
--- a/packages/astro-md/middleware.ts
+++ b/packages/astro-md/middleware.ts
@@ -6,15 +6,8 @@ import { normalizeFrontmatter } from "../my-remark";
 import { remarkObsidian } from "../remark-obsidian";
 import remarkFrontmatter from "remark-frontmatter";
 
-function isULID(str: string) {
-  // ULID regex to validate the format
-  const ulidRegex = /^[0-9A-HJKMNP-TV-Z]{26}$/i;
-  return ulidRegex.test(str);
-}
-
 export const onRequest = defineMiddleware(async (context, next) => {
   const fileResolver = async (path: string) => {
-    if (isULID(path)) return path;
     return (await context.locals.runtime.env.KV_MAPPINGS.get(path)) ?? path;
   };
   const processor = await createMarkdownProcessor({

--- a/src/pages/api/[...path].ts
+++ b/src/pages/api/[...path].ts
@@ -31,7 +31,7 @@ const app = new Hono<{ Bindings: AstroContext }>()
       throw new Error("Title or H1s should not be a ULID");
     }
 
-    const primaryTag = props.tags.split(",")[0];
+    const primaryTag = props.tags?.split(",")[0];
     // Set the prefix URL to the first tag (or it's mapped value) if it exists
     if (primaryTag && primaryTag !== slug) {
       slug = `${


### PR DESCRIPTION
Fixes #42 #45

This changes the publishing model to be based on the slugified title (either the `title` property in front matter or the first H1) and the primary tag (if one is present). I also added the notion of a tag mapping so I can change certain tags to be different URLs. E.g. I've got the `recurse` tag mapped to `rc`. So note titled `Hello world` with the tag `Recurse` would end up with a url `/rc/hello-world`. 

This also required some publishing updates. Note that the URLs rendered in the UI now point to whatever the canonical version is. 
