### PR TITLE
Show draft warning; auto add publish dates

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -3,7 +3,7 @@
 import { defineConfig } from "astro/config";
 import tailwind from "@astrojs/tailwind";
 import cloudflare from "@astrojs/cloudflare";
-import { normalizeFrontmatter } from "./packages/my-remark";
+import { myRemark } from "./packages/my-remark";
 import mdRenderer from "./packages/astro-md";
 import astroCloudflareSentry from "./packages/astro-cf-sentry";
 import fullReload from "vite-plugin-full-reload";
@@ -20,7 +20,7 @@ export default defineConfig({
    */
   output: "server",
   markdown: {
-    remarkPlugins: [normalizeFrontmatter],
+    remarkPlugins: [myRemark],
   },
   integrations: [
     mdRenderer(),

--- a/packages/astro-md/middleware.ts
+++ b/packages/astro-md/middleware.ts
@@ -2,7 +2,7 @@
 
 import { createMarkdownProcessor } from "@astrojs/markdown-remark";
 import { defineMiddleware } from "astro:middleware";
-import { normalizeFrontmatter } from "../my-remark";
+import { myRemark } from "../my-remark";
 import { remarkObsidian } from "../remark-obsidian";
 import remarkFrontmatter from "remark-frontmatter";
 
@@ -13,7 +13,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const processor = await createMarkdownProcessor({
     remarkPlugins: [
       remarkFrontmatter,
-      normalizeFrontmatter,
+      myRemark,
       remarkObsidian({ fileResolver }),
     ],
   });

--- a/packages/my-remark/index.ts
+++ b/packages/my-remark/index.ts
@@ -7,7 +7,7 @@ export const myRemark: RemarkPlugin = () => {
     // Populate frontmatter
     matter(file);
     const fm = ((file.data.astro as MarkdownAstroData).frontmatter = file.data
-      .matter as Record<string, unknown>);
+      .matter as Record<string, any>);
 
     /**
      * Treat the homepage as a special case for layouts and fallback to default.
@@ -33,6 +33,40 @@ export const myRemark: RemarkPlugin = () => {
         (node) => node.type === "heading" && node.depth === 1
       ) as Heading | undefined;
       fm.title = title?.children.find((node) => node.type === "text")?.value;
+    }
+
+    if (fm.stage === "draft" || fm.stage?.[0] === "draft") {
+      const draftCallout = {
+        type: "html" as const,
+        value: "<i>This document is a work in progress</i>",
+      };
+
+      const firstHeadingIndex = root.children.findIndex(
+        (node) => node.type === "heading" && node.depth === 1
+      );
+
+      if (firstHeadingIndex !== -1) {
+        root.children.splice(firstHeadingIndex + 1, 0, draftCallout);
+      } else {
+        root.children.unshift(draftCallout);
+      }
+    }
+
+    if (fm.published) {
+      const publishedLabel = {
+        type: "html" as const,
+        value: `<p><sup ${
+          fm.updated ? `title="Published on ${fm.published}"` : ""
+        }>${fm.updated ?? fm.published}</sup></p>`,
+      };
+
+      const firstHeadingIndex = root.children.findIndex(
+        (node) => node.type === "heading" && node.depth === 1
+      );
+
+      if (firstHeadingIndex !== -1) {
+        root.children.splice(firstHeadingIndex + 1, 0, publishedLabel);
+      }
     }
   };
 };

--- a/packages/my-remark/index.ts
+++ b/packages/my-remark/index.ts
@@ -2,7 +2,7 @@ import type { MarkdownAstroData, RemarkPlugin } from "@astrojs/markdown-remark";
 import type { Heading } from "mdast";
 import { matter } from "vfile-matter";
 
-export const normalizeFrontmatter: RemarkPlugin = () => {
+export const myRemark: RemarkPlugin = () => {
   return (root, file) => {
     // Populate frontmatter
     matter(file);
@@ -37,4 +37,4 @@ export const normalizeFrontmatter: RemarkPlugin = () => {
   };
 };
 
-export default normalizeFrontmatter;
+export default myRemark;

--- a/scripts/ob.ts
+++ b/scripts/ob.ts
@@ -83,6 +83,11 @@ async function publishNote(path: string) {
 
   fm.title ??= await extractH1(path);
 
+  // Normalize stage to a string if it's an array
+  if (Array.isArray(fm.stage)) {
+    fm.stage = fm.stage[0];
+  }
+
   return fetch(
     `${Deno.env.get("SITE")}/api/notes/${file}${
       fm ? "?" + new URLSearchParams(fm).toString() : ""

--- a/scripts/ob.ts
+++ b/scripts/ob.ts
@@ -16,7 +16,7 @@ async function extractH1(path: string): Promise<string> {
 
   let content = "";
 
-  const buf = new Uint8Array(100);
+  const buf = new Uint8Array(1024);
   while (true) {
     const bytesRead = await file.read(buf);
     if (bytesRead === null) break;

--- a/src/pages/all.astro
+++ b/src/pages/all.astro
@@ -1,0 +1,48 @@
+---
+import Layout from "../layouts/default.astro";
+let { objects: pages } = await Astro.locals.runtime.env.R2_BUCKET.list({
+  prefix: "0",
+  // @ts-expect-error This is actually supported but the types are wrong
+  include: ["customMetadata"],
+});
+---
+
+<Layout title="All Pages">
+  <p>
+    Here you can find all the pages on my site, event the stuff in progress. If
+    the url is an ULID then the page is still a draft. Though, that doesn't mean
+    the things with regular URLs are finished!
+  </p>
+
+  <table class="table-auto">
+    <thead>
+      <tr>
+        <th>Slug</th>
+        <th>Stage</th>
+        <th>Published</th>
+        <th>Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      {
+        pages.map(({ key, customMetadata: m }) => (
+          <tr>
+            <td>
+              <a href={`/${key}`}>{m?.title ?? m?.slug ?? key}</a>
+            </td>
+            <td>{m?.stage ?? "draft"}</td>
+            <td>{m?.published ?? "-"}</td>
+            <td>{m?.updated ?? "-"}</td>
+          </tr>
+        ))
+      }
+    </tbody>
+  </table>
+</Layout>
+
+<style>
+  th,
+  td {
+    @apply px-3;
+  }
+</style>

--- a/src/style.css
+++ b/src/style.css
@@ -28,6 +28,7 @@ h2:has(+ p > sup) {
 
 h1 + p:has(> sup) {
   margin-top: 0rem !important;
+  margin-bottom: 0.5rem !important;
 }
 h1 + p > sup,
 h2 + p > sup {


### PR DESCRIPTION
This PR ended up being a bit larger than anticipated. 

- A rename in the `my-remark` package export: `normalizeFrontmatter` -> `myRemark`
- Update `my-remark` to automatically add published/updated times
- Update `my-remark` to add a text warning if a document is in draft
- Update the publishing script to write published/updated dates back to the markdown file
- Update the publishing script to use `stage` instead of `draft`
- Update the publish api to use stage instead of draft. 
- Update the publish api to associate file metadata with the R2 upload via [`customMetadata`](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/#r2object-definition)
- Add an `/all` page to list all pages and their states (via the metadata in the bucket)