### PR TITLE
Run check and build in the test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,9 @@ jobs:
 
       - name: Run Vitest
         run: pnpm run test
+
+      - name: Run Astro check
+        run: pnpm run astro check
+
+      - name: Run Astro build
+        run: pnpm run build


### PR DESCRIPTION
`check` and `build` find errors that causes cf deployments to fail. I'd rather catch those in github actions. 