### PR TITLE
Use `publish` date for events instead of `update`.

### DIFF
--- a/packages/my-remark/index.ts
+++ b/packages/my-remark/index.ts
@@ -53,19 +53,22 @@ export const myRemark: RemarkPlugin = () => {
     }
 
     if (fm.published) {
-      const publishedLabel = {
+      let dateLabel = {
         type: "html" as const,
-        value: `<p><sup ${
-          fm.updated ? `title="Published on ${fm.published}"` : ""
-        }>${fm.updated ?? fm.published}</sup></p>`,
+        value: `<p><sup>${fm.published}</sup></p>`,
       };
+
+      // If the document is associated with an event, skip showing the updated date
+      if (fm.updated && !fm.tags?.includes("events")) {
+        dateLabel.value = `<p><sup title="Published on ${fm.published}">${fm.updated}</sup></p>`;
+      }
 
       const firstHeadingIndex = root.children.findIndex(
         (node) => node.type === "heading" && node.depth === 1
       );
 
       if (firstHeadingIndex !== -1) {
-        root.children.splice(firstHeadingIndex + 1, 0, publishedLabel);
+        root.children.splice(firstHeadingIndex + 1, 0, dateLabel);
       }
     }
   };

--- a/scripts/ob.ts
+++ b/scripts/ob.ts
@@ -75,10 +75,6 @@ async function publishNote(path: string) {
       fm.updated = today;
       await updateFrontmatter(path, fm);
     }
-    if (fm.draft === false) {
-      delete fm.draft;
-      await updateFrontmatter(path, fm);
-    }
   }
 
   fm.title ??= await extractH1(path);


### PR DESCRIPTION
When I write something about an event, it's likely best just to have the date pinned to when I started writing about it (around the time of the event) instead of when I've updated it. 