### PR TITLE
Update decoding strategy to properly account for hex chars

### DIFF
--- a/packages/astro-md/middleware.ts
+++ b/packages/astro-md/middleware.ts
@@ -7,7 +7,7 @@ import { remarkObsidian } from "../remark-obsidian";
 import remarkFrontmatter from "remark-frontmatter";
 
 const decode = (str: string) =>
-  str.replace(/&#x(\d+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+  str.replace(/&#x(\w+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
 
 const theme = "nord";
 


### PR DESCRIPTION
I was working on a post around the syntax highlighting and this happened:

![CleanShot 2024-10-06 at 14 24 22@2x](https://github.com/user-attachments/assets/06d9335e-7a7a-49bd-a813-9240b5de3c78)

Turns out the regex I was using to swap out html encoded chars was using `\d` which won't work for hex because it contains letters. Just swapped it out for a `\w` which fixes things up. 

I kinda need a way to purge the cache... 🤔 