### PR TITLE
Fix preview deploys being disabled

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,7 +9,3 @@ enabled = true
 [assets]
 directory = "./dist"
 binding = "ASSETS"
-
-[[routes]]
-pattern = "just-be.dev"
-custom_domain = true


### PR DESCRIPTION
I’ve had this weird behavior where preview deploys are getting automatically disabled after every deploy I do. I think it might be due to the fact that I’m explicitly setting the domain in the wrangler config. Dropping that to see if it makes a difference.