### PR TITLE
Configure Renovate to automerge @types/* packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,5 +4,12 @@
     "config:best-practices",
     "mergeConfidence:all-badges"
   ],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "Automerge TypeScript type definitions if CI passes",
+      "matchPackagePatterns": ["^@types/"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Add packageRules to automerge TypeScript type definition packages when CI passes. This reduces manual intervention for low-risk dependency updates.

Fixes #148

Generated with [Claude Code](https://claude.ai/code)