### PR TITLE
Add 12-hour buffer to Renovate's minimumReleaseAge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,7 @@
     "config:best-practices",
     "mergeConfidence:all-badges"
   ],
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "7 days 12 hours",
   "packageRules": [
     {
       "description": "Automerge TypeScript type definitions if CI passes",


### PR DESCRIPTION
This prevents timing synchronization issues between Renovate's
release age checks and Bun's package manager checks, ensuring
packages have definitively met the minimum release age before
PRs are created.
