### PR TITLE
Move content codes from filenames to frontmatter

### DIFF
--- a/scripts/prefix-codes.ts
+++ b/scripts/prefix-codes.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
-import { $ } from "bun";
+import { existsSync, readdirSync, readFileSync, writeFileSync, renameSync } from "node:fs";
+import { join } from "node:path";
 import { Code, type Kind } from "../src/utils/code";
 
 const CONTENT_DIR = `${import.meta.dir}/../src/content`;
@@ -25,18 +26,102 @@ function inferKind(dir: string): Kind {
 }
 
 /**
+ * Parse frontmatter from MDX content
+ */
+function parseFrontmatter(content: string): { data: Record<string, any>; body: string } {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    return { data: {}, body: content };
+  }
+
+  const yamlStr = match[1];
+  const body = match[2];
+  const data = Bun.YAML.parse(yamlStr) as Record<string, any>;
+
+  return { data, body };
+}
+
+/**
+ * Stringify a YAML value with proper indentation
+ */
+function stringifyYAMLValue(value: any, indent: number): string[] {
+  const lines: string[] = [];
+  const indentStr = "  ".repeat(indent);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === "object" && item !== null) {
+        lines.push(`${indentStr}-`);
+        for (const [k, v] of Object.entries(item)) {
+          if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+            lines.push(`${indentStr}  ${k}:`);
+            lines.push(...stringifyYAMLValue(v, indent + 2));
+          } else if (Array.isArray(v)) {
+            lines.push(`${indentStr}  ${k}:`);
+            lines.push(...stringifyYAMLValue(v, indent + 2));
+          } else {
+            lines.push(`${indentStr}  ${k}: ${v}`);
+          }
+        }
+      } else {
+        lines.push(`${indentStr}- ${item}`);
+      }
+    }
+  } else if (typeof value === "object" && value !== null) {
+    for (const [k, v] of Object.entries(value)) {
+      if (typeof v === "object" && v !== null && !Array.isArray(v)) {
+        lines.push(`${indentStr}${k}:`);
+        lines.push(...stringifyYAMLValue(v, indent + 1));
+      } else if (Array.isArray(v)) {
+        lines.push(`${indentStr}${k}:`);
+        lines.push(...stringifyYAMLValue(v, indent + 1));
+      } else {
+        lines.push(`${indentStr}${k}: ${v}`);
+      }
+    }
+  }
+
+  return lines;
+}
+
+/**
+ * Stringify frontmatter data into YAML format
+ */
+function stringifyFrontmatter(data: Record<string, any>): string {
+  const lines: string[] = [];
+
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      lines.push(...stringifyYAMLValue(value, 1));
+    } else if (typeof value === "object" && value !== null) {
+      lines.push(`${key}:`);
+      lines.push(...stringifyYAMLValue(value, 1));
+    } else {
+      lines.push(`${key}: ${value}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
  * Extract the date from MDX frontmatter
  */
 function extractDate(content: string): string | null {
-  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!frontmatterMatch) {
-    return null;
-  }
+  const { data } = parseFrontmatter(content);
+  return data.date ? String(data.date) : null;
+}
 
-  const frontmatter = frontmatterMatch[1];
-  const dateMatch = frontmatter.match(/^date:\s*(.+)$/m);
+/**
+ * Update or add the code field in frontmatter
+ */
+function updateFrontmatterCode(content: string, code: string): string {
+  const { data, body } = parseFrontmatter(content);
+  data.code = code;
 
-  return dateMatch ? dateMatch[1].trim() : null;
+  const frontmatter = stringifyFrontmatter(data);
+  return `---\n${frontmatter}\n---\n${body}`;
 }
 
 /**
@@ -63,13 +148,12 @@ function hasOldCodePrefix(filename: string): boolean {
 /**
  * Process files in a single directory
  */
-async function processDirectory(dir: string) {
-  const dirPath = `${CONTENT_DIR}/${dir}`;
+function processDirectory(dir: string) {
+  const dirPath = join(CONTENT_DIR, dir);
   const kind = inferKind(dir);
 
   // Check if directory exists
-  const exists = await $`test -d ${dirPath}`.nothrow().quiet();
-  if (exists.exitCode !== 0) {
+  if (!existsSync(dirPath)) {
     console.log(`⚠️  Directory ${dir} does not exist, skipping...\n`);
     return { processed: 0, skipped: 0, errors: 0, total: 0 };
   }
@@ -77,13 +161,15 @@ async function processDirectory(dir: string) {
   console.log(`Processing files in: ${dir} (kind: ${kind})\n`);
 
   // Get all .mdx files
-  const files = await $`ls ${dirPath}/*.mdx 2>/dev/null`.nothrow().quiet();
-  if (files.exitCode !== 0) {
+  const allFiles = readdirSync(dirPath);
+  const mdxFiles = allFiles
+    .filter((file) => file.endsWith(".mdx"))
+    .map((file) => join(dirPath, file));
+
+  if (mdxFiles.length === 0) {
     console.log(`No .mdx files found in ${dir}\n`);
     return { processed: 0, skipped: 0, errors: 0, total: 0 };
   }
-
-  const mdxFiles = files.text().trim().split("\n").filter(Boolean);
 
   let processedCount = 0;
   let skippedCount = 0;
@@ -97,21 +183,48 @@ async function processDirectory(dir: string) {
       if (hasUppercasePrefix(filename)) {
         const lowercaseFilename = filename.substring(0, 5).toLowerCase() + filename.substring(5);
         const newFilePath = filePath.replace(filename, lowercaseFilename);
-        await $`mv ${filePath} ${newFilePath}`;
-        console.log(`🔄 ${filename} → ${lowercaseFilename} (converted to lowercase)`);
+
+        // Read content and update frontmatter with code
+        const content = readFileSync(filePath, "utf-8");
+        const codeStr = lowercaseFilename.substring(0, 5);
+        const updatedContent = updateFrontmatterCode(content, codeStr);
+
+        // Write updated content
+        writeFileSync(filePath, updatedContent);
+
+        // Rename file
+        renameSync(filePath, newFilePath);
+        console.log(
+          `🔄 ${filename} → ${lowercaseFilename} (converted to lowercase, added code to frontmatter)`
+        );
         processedCount++;
         continue;
       }
 
-      // Skip if already has new 5-char code prefix
+      // Check if file already has new 5-char code prefix
       if (hasCodePrefix(filename)) {
-        console.log(`⏭  Skipping ${filename} (already has code prefix)`);
-        skippedCount++;
+        // Read content to check if code is in frontmatter
+        const content = readFileSync(filePath, "utf-8");
+        const codeStr = filename.substring(0, 5);
+
+        // Check if code field already exists in frontmatter
+        const { data } = parseFrontmatter(content);
+        if (data.code === codeStr) {
+          console.log(`⏭  Skipping ${filename} (already has code in filename and frontmatter)`);
+          skippedCount++;
+          continue;
+        }
+
+        // Add code to frontmatter
+        const updatedContent = updateFrontmatterCode(content, codeStr);
+        writeFileSync(filePath, updatedContent);
+        console.log(`✅ ${filename} (added code to frontmatter)`);
+        processedCount++;
         continue;
       }
 
       // Read file content
-      const content = await $`cat ${filePath}`.text();
+      const content = readFileSync(filePath, "utf-8");
 
       // Extract date from frontmatter
       const dateString = extractDate(content);
@@ -125,6 +238,9 @@ async function processDirectory(dir: string) {
       const code = Code.fromDateString(dateString, kind);
       const codeStr = code.toString().toLowerCase();
 
+      // Update frontmatter with code
+      const updatedContent = updateFrontmatterCode(content, codeStr);
+
       // Determine base filename (strip old code if present)
       let baseFilename = filename;
       if (hasOldCodePrefix(filename)) {
@@ -137,8 +253,13 @@ async function processDirectory(dir: string) {
       const newFilename = `${codeStr}--${baseFilename}`;
       const newFilePath = filePath.replace(filename, newFilename);
 
-      // Rename file
-      await $`mv ${filePath} ${newFilePath}`;
+      // Write updated content
+      writeFileSync(filePath, updatedContent);
+
+      // Rename file if needed
+      if (filePath !== newFilePath) {
+        renameSync(filePath, newFilePath);
+      }
       console.log(`✅ ${filename} → ${newFilename} (${dateString})`);
       processedCount++;
     } catch (error) {
@@ -162,7 +283,7 @@ async function processDirectory(dir: string) {
 /**
  * Main function to prefix files with their date codes
  */
-async function prefixCodes(dirs: string[]) {
+function prefixCodes(dirs: string[]) {
   console.log(`Content directory: ${CONTENT_DIR}`);
   console.log(`Directories to process: ${dirs.join(", ")}\n`);
   console.log("=".repeat(50) + "\n");
@@ -173,7 +294,7 @@ async function prefixCodes(dirs: string[]) {
   let totalFiles = 0;
 
   for (const dir of dirs) {
-    const result = await processDirectory(dir);
+    const result = processDirectory(dir);
     totalProcessed += result.processed;
     totalSkipped += result.skipped;
     totalErrors += result.errors;
@@ -193,7 +314,9 @@ async function prefixCodes(dirs: string[]) {
 const dirs = process.argv.slice(2).length > 0 ? process.argv.slice(2) : DEFAULT_DIRS;
 
 // Run the script
-prefixCodes(dirs).catch((error) => {
+try {
+  prefixCodes(dirs);
+} catch (error) {
   console.error("Fatal error:", error);
   process.exit(1);
-});
+}

--- a/src/components/LatestPosts.astro
+++ b/src/components/LatestPosts.astro
@@ -10,7 +10,10 @@ const { limit = 5 } = Astro.props;
 
 // Get latest published blog posts
 const latestPosts = (await getCollection("blog", ({ data }) => import.meta.env.DEV || !data.draft))
-  .map((post) => ({ ...post, code: Code.fromId(post.id) }))
+  .map((post) => ({
+    ...post,
+    code: post.data.code || Code.fromId(post.id).toString(),
+  }))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf())
   .slice(0, limit);
 ---
@@ -27,7 +30,7 @@ const latestPosts = (await getCollection("blog", ({ data }) => import.meta.env.D
               href={Code.buildUrl("blog", post.id)}
               class="bg-0 hocus:invert group col-span-3 -mx-[1ch] grid grid-cols-subgrid outline-none"
             >
-              <code class="text-fg-2 group-hocus:text-accent">{post.code.toString()}</code>
+              <code class="text-fg-2 group-hocus:text-accent">{post.code}</code>
               <span class="text-fg-2 group-hocus:text-accent whitespace-nowrap">{date}</span>
               <h3 class="font-bold whitespace-nowrap mb-0">{post.data.title}</h3>
             </a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,6 +12,7 @@ const blog = defineCollection({
     date: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
+    code: z.string().optional(),
   }),
 });
 
@@ -24,6 +25,7 @@ const projects = defineCollection({
     repository: z.string().url().optional(),
     status: z.enum(["active", "completed", "archived", "maintenance"]).default("active"),
     date: z.coerce.date(),
+    code: z.string().optional(),
   }),
 });
 
@@ -36,6 +38,7 @@ const research = defineCollection({
     lastUpdated: z.coerce.date().optional(),
     status: z.enum(["draft", "published", "archived"]).default("draft"),
     topics: z.array(z.string()).default([]),
+    code: z.string().optional(),
   }),
 });
 
@@ -60,6 +63,7 @@ const talks = defineCollection({
       .optional(),
     audioPath: z.string().optional(),
     transcriptPath: z.string().optional(),
+    code: z.string().optional(),
   }),
 });
 

--- a/src/content/blog/b232e--building-a-deno-desktop-framework.mdx
+++ b/src/content/blog/b232e--building-a-deno-desktop-framework.mdx
@@ -1,7 +1,9 @@
 ---
-tags: [recurse]
+tags:
+  - recurse
 date: 2024-08-28
 title: Building a Deno Desktop Framework
+code: b232e
 ---
 
 ## Goal

--- a/src/content/blog/b2405--apis-in-the-age-of-ai.mdx
+++ b/src/content/blog/b2405--apis-in-the-age-of-ai.mdx
@@ -1,7 +1,11 @@
 ---
 title: APIs in the Age of AI
 date: 2025-03-31
-tags: [ai, mcp, api]
+tags:
+  - ai
+  - mcp
+  - api
+code: b2405
 ---
 
 I think we're on the cusp of a shift in how people interact with software services. Steve Manuel, CEO of Dylibso, wrote a post called [MCP: The Differential for Modern APIs and Systems](https://docs.mcp.run/blog/2025/03/27/mcp-differential-for-modern-apis/) where he describes Anthropic's Model Context Protocol (MCP) as a kind of fuzzy interface between users and the systems they want to interact with. MCP is essentially a protocol that describes how LLMs can interact with APIs and services. It's worth reading more about.

--- a/src/content/blog/b24f9--the-values-I-build-by.mdx
+++ b/src/content/blog/b24f9--the-values-I-build-by.mdx
@@ -2,7 +2,10 @@
 title: The Values I Build By
 date: 2025-11-30
 description: Reflecting on the values that guide my design and development process.
-tags: [meta, web]
+tags:
+  - meta
+  - web
+code: b24f9
 ---
 
 If a thing is worth doing, it's worth doing well. When it's something personal though, what does _well_ mean? I believe that having strong values that guide your decisions and building according to those values is all the measure that's needed. Here are the values I've developed over my career that have guided the design of this site.

--- a/src/content/blog/b252b--why-i-built-a-claude-code-plugin-marketplace.mdx
+++ b/src/content/blog/b252b--why-i-built-a-claude-code-plugin-marketplace.mdx
@@ -1,10 +1,13 @@
 ---
-title: "Build Yourself a Claude Code Plugin Marketplace"
-description: "The utility of a plugin marketplace for Claude Code and why you should make one"
+title: Build Yourself a Claude Code Plugin Marketplace
+description: The utility of a plugin marketplace for Claude Code and why you should make one
 date: 2026-01-19
-tags: [ai, claude]
+tags:
+  - ai
+  - claude
 defs:
   cc: Claude Code
+code: b252b
 ---
 
 There's a lot of ways to configure [Claude Code](https://code.claude.com/docs/en/overview) (:def[CC]{:title=defs.cc}) now. There are [custom slash commands](https://code.claude.com/docs/en/slash-commands), [skills](https://code.claude.com/docs/en/skills#agent-skills), [hooks](https://code.claude.com/docs/en/hooks-guide), [subagents](https://code.claude.com/docs/en/sub-agents), and [mcp servers](https://code.claude.com/docs/en/mcp).
@@ -69,7 +72,7 @@ The one thing I will callout is that a plugin's `version` field _is_ required an
 
 ## Uses for Marketplaces
 
-I'm just starting out, but there are a few things I'm already using marketplaces for. 
+I'm just starting out, but there are a few things I'm already using marketplaces for.
 
 ### Configuring Tools in New Projects
 
@@ -77,7 +80,7 @@ I use [Mise](https://github.com/jdx/mise) in essentially all of my projects now.
 
 ### Meta Marketplace Updates
 
-Another fun usage use my [meta plugin](https://github.com/just-be-dev/ccpm/tree/main/plugins/meta) which helps update the marketplace itself. I have a [create plugin](https://github.com/just-be-dev/ccpm/blob/main/plugins/meta/commands/create-plugin.md) command that uses the github CLI to open an issue on the marketplace repo and to invoke `@claude` which'll kick off the claude GitHub app. That'll only work for my user account. It's a fun (if convoluted) way of being able to add plugins to my marketplace from any claude instance. 
+Another fun usage use my [meta plugin](https://github.com/just-be-dev/ccpm/tree/main/plugins/meta) which helps update the marketplace itself. I have a [create plugin](https://github.com/just-be-dev/ccpm/blob/main/plugins/meta/commands/create-plugin.md) command that uses the github CLI to open an issue on the marketplace repo and to invoke `@claude` which'll kick off the claude GitHub app. That'll only work for my user account. It's a fun (if convoluted) way of being able to add plugins to my marketplace from any claude instance.
 
 ## Marketplace Maintenance
 

--- a/src/content/projects/p1e73--devtools-fm.mdx
+++ b/src/content/projects/p1e73--devtools-fm.mdx
@@ -4,6 +4,7 @@ description: A podcast about developer tools and the people who make them
 status: active
 date: 2021-05-05
 url: https://devtools.fm
+code: p1e73
 ---
 
 I started DevTools.fm with [Andrew Lisowski](https://www.hipstersmoothie.com/) back in 2021 after he started working at Descript. We'd met through collaborating in dev tools on GitHub so it seemed like a natural fit. It's been a blast.

--- a/src/content/projects/p2323--side-project-saturday.mdx
+++ b/src/content/projects/p2323--side-project-saturday.mdx
@@ -4,6 +4,7 @@ description: A weekly meetup for working on side projects
 status: active
 date: 2024-08-17
 url: https://sideprojectsaturday.com
+code: p2323
 ---
 
 Side Project Saturday is a weekly meetup where developers get together to work on their side projects. It's a casual, collaborative environment focused on building things and sharing progress.

--- a/src/content/projects/p252b--ccpm.mdx
+++ b/src/content/projects/p252b--ccpm.mdx
@@ -1,10 +1,11 @@
 ---
-title: "CCPM"
-description: "My personal Claude Code Plugin Marketplace"
-url: "https://github.com/just-be-dev/ccpm"
-repository: "https://github.com/just-be-dev/ccpm"
-status: "active"
+title: CCPM
+description: My personal Claude Code Plugin Marketplace
+url: https://github.com/just-be-dev/ccpm
+repository: https://github.com/just-be-dev/ccpm
+status: active
 date: 2026-01-19
+code: p252b
 ---
 
 ::readme{repo="just-be-dev/ccpm"}

--- a/src/content/projects/p3a89--webview.mdx
+++ b/src/content/projects/p3a89--webview.mdx
@@ -4,6 +4,7 @@ description: A scriptable webview framework
 status: maintenance
 date: 2024-09-16
 url: https://github.com/just-be-dev/webview
+code: p3a89
 ---
 
 ::readme{repo="just-be-dev/webview"}

--- a/src/content/research/r24e5--parsing-techniques.mdx
+++ b/src/content/research/r24e5--parsing-techniques.mdx
@@ -2,8 +2,12 @@
 title: Parsing Techniques Overview
 date: 2025-11-10
 lastUpdated: 2025-11-15
-topics: [compilers, parsing, theory]
+topics:
+  - compilers
+  - parsing
+  - theory
 status: published
+code: r24e5
 ---
 
 # Parsing Techniques Overview

--- a/src/content/talks/t2468--codegen-in-rust.mdx
+++ b/src/content/talks/t2468--codegen-in-rust.mdx
@@ -112,4 +112,5 @@ slides:
     timestamp: 30:41
 audioPath: /assets/talks/codegen-in-rust/audio.m4a
 transcriptPath: /assets/talks/codegen-in-rust/transcript.json
+code: t2468
 ---

--- a/src/pages/blog/[code]/[slug].astro
+++ b/src/pages/blog/[code]/[slug].astro
@@ -17,8 +17,8 @@ type Props = Awaited<ReturnType<typeof getStaticPaths>>[number]["props"];
 const post = Astro.props;
 const { Content } = await render(post);
 
-// Extract code from filename (e.g., "0745--apis-in-the-age-of-ai" -> "0745")
-const code = Code.fromId(post.id);
+// Get code from frontmatter, fallback to parsing filename for backwards compatibility
+const code = post.data.code || Code.fromId(post.id).toString();
 ---
 
 <Layout title={`${post.data.title} - Just Be`} description={post.data.description}>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -14,7 +14,10 @@ const selectedTag = Astro.url.searchParams.get("tag");
 const publishedPosts = (
   await getCollection("blog", ({ data }) => import.meta.env.DEV || !data.draft)
 )
-  .map((post) => ({ ...post, code: Code.fromId(post.id) }))
+  .map((post) => ({
+    ...post,
+    code: post.data.code || Code.fromId(post.id).toString(),
+  }))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 
 // Filter posts if tag is selected
@@ -68,7 +71,7 @@ const sortedTags = Array.from(tagCounts.entries())
               href={Code.buildUrl("blog", post.id)}
               class="bg-0 hocus:invert group col-span-3 -mx-[1ch] grid grid-cols-subgrid px-[1ch] outline-none"
             >
-              <code class="text-fg-2 group-hocus:text-accent">{post.code.toString()}</code>
+              <code class="text-fg-2 group-hocus:text-accent">{post.code}</code>
               <span class="text-fg-2 group-hocus:text-accent whitespace-nowrap">{date}</span>
               <h2 class="font-bold whitespace-nowrap">{post.data.title}</h2>
             </a>

--- a/src/pages/projects/[code]/[slug].astro
+++ b/src/pages/projects/[code]/[slug].astro
@@ -28,8 +28,8 @@ if (!project) {
 
 const { Content } = await render(project);
 
-// Extract code from filename
-const code = Code.fromId(project.id);
+// Get code from frontmatter, fallback to parsing filename for backwards compatibility
+const code = project.data.code || Code.fromId(project.id).toString();
 ---
 
 <Layout title={`${project.data.title} - Just Be`} description={project.data.description}>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -5,7 +5,10 @@ import ProjectStatus from "@/components/ProjectStatus.astro";
 import { Code } from "@/utils/code";
 
 const projects = (await getCollection("projects"))
-  .map((post) => ({ ...post, code: Code.fromId(post.id) }))
+  .map((post) => ({
+    ...post,
+    code: post.data.code || Code.fromId(post.id).toString(),
+  }))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 
@@ -22,7 +25,7 @@ const projects = (await getCollection("projects"))
             href={Code.buildUrl("projects", project.id)}
             class="bg-0 hocus:invert group col-span-3 -mx-[1ch] grid grid-cols-subgrid px-[1ch] outline-none"
           >
-            <code class="text-fg-2 group-hocus:text-accent">{project.code.toString()}</code>
+            <code class="text-fg-2 group-hocus:text-accent">{project.code}</code>
             <ProjectStatus status={project.data.status} />
             <h2 class="truncate font-bold">
               {project.data.title}

--- a/src/pages/talks/[code]/[slug].astro
+++ b/src/pages/talks/[code]/[slug].astro
@@ -19,8 +19,8 @@ type Props = Awaited<ReturnType<typeof getStaticPaths>>[number]["props"];
 const talk = Astro.props;
 const { Content } = await render(talk);
 
-// Extract code and slug from filename
-const code = Code.fromId(talk.id);
+// Get code from frontmatter, fallback to parsing filename for backwards compatibility
+const code = talk.data.code || Code.fromId(talk.id).toString();
 const { slug } = Code.parseId(talk.id);
 
 // Check if this talk has slides/audio/transcript

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -4,7 +4,10 @@ import Layout from "@/layouts/Layout.astro";
 import { Code } from "@/utils/code";
 
 const talks = (await getCollection("talks"))
-  .map((talk) => ({ ...talk, code: Code.fromId(talk.id) }))
+  .map((talk) => ({
+    ...talk,
+    code: talk.data.code || Code.fromId(talk.id).toString(),
+  }))
   .sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 ---
 
@@ -23,7 +26,7 @@ const talks = (await getCollection("talks"))
               href={Code.buildUrl("talks", talk.id)}
               class="bg-0 hocus:invert group col-span-3 -mx-[1ch] grid grid-cols-subgrid px-[1ch] outline-none"
             >
-              <code class="text-fg-2 group-hocus:text-accent">{talk.code.toString()}</code>
+              <code class="text-fg-2 group-hocus:text-accent">{talk.code}</code>
               <span class="text-fg-2 group-hocus:text-accent whitespace-nowrap">{date}</span>
               <h2 class="font-bold whitespace-nowrap">{talk.data.title}</h2>
             </a>


### PR DESCRIPTION
## Summary
Store content codes (blog, projects, research, talks) in YAML frontmatter instead of requiring them in filenames. All content pages and components now read codes from frontmatter with backwards-compatible fallback to filename parsing. Implemented custom frontmatter parser using Bun's native YAML support to avoid external dependencies.

## Changes
- Add `code` field to all content collection schemas
- Update `prefix-codes.ts` script with custom YAML serialization
- Update all page components to read codes from frontmatter
- All 10 content files now have codes in frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)