### PR TITLE
Add URL manifest validation tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "astro-site",
@@ -23,8 +22,10 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.6",
+        "@types/js-yaml": "^4.0.9",
         "@unocss/astro": "66.5.10",
         "@unocss/preset-icons": "66.5.10",
+        "js-yaml": "^4.1.1",
         "prettier": "3.7.4",
         "prettier-plugin-astro": "0.14.1",
         "unocss": "66.5.10",
@@ -451,6 +452,8 @@
     "@types/fontkit": ["@types/fontkit@2.0.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-wN+8bYxIpJf+5oZdrdtaX04qUuWHcKxcDEgRS9Qm9ZClSHjzEn13SxUC+5eRM+4yXIeTYk8mTzLAWGF64847ew=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 

--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   "type": "module",
   "devDependencies": {
     "@types/bun": "1.3.6",
+    "@types/js-yaml": "^4.0.9",
     "@unocss/astro": "66.5.10",
     "@unocss/preset-icons": "66.5.10",
+    "js-yaml": "^4.1.1",
     "prettier": "3.7.4",
     "prettier-plugin-astro": "0.14.1",
     "unocss": "66.5.10",

--- a/scripts/gen-url-manifest.ts
+++ b/scripts/gen-url-manifest.ts
@@ -65,7 +65,7 @@ function processCollection(
 
   for (const filePath of mdxFiles) {
     const filename = filePath.split("/").pop()!;
-    const slug = filename.replace(/\.(mdx?|md)$/, "");
+    const slug = filename.replace(/\.(mdx?|md)$/, "").toLowerCase();
 
     try {
       // Read file content

--- a/src/content/url-manifest.yaml
+++ b/src/content/url-manifest.yaml
@@ -9,7 +9,7 @@ codes:
   b2405:
     - /blog/apis-in-the-age-of-ai
   b24f9:
-    - /blog/the-values-I-build-by
+    - /blog/the-values-i-build-by
   b252b:
     - /blog/why-i-built-a-claude-code-plugin-marketplace
   p1e73:

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,9 +3,13 @@ import { getCollection } from "astro:content";
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const url = new URL(context.request.url);
-  const pathSegments = url.pathname.split("/").filter(Boolean);
+  const pathname = url.pathname;
+  const pathSegments = pathname.split("/").filter(Boolean);
 
-  // Check if first or second path segment is a code (format: [brpt][0-9a-f]{4})
+  // Load the URL manifest
+  const entries = await getCollection("urls");
+
+  // Check if first or second path segment is a short code (format: [brpt][0-9a-f]{4})
   const codePattern = /^[brpt][0-9a-f]{4}$/i;
   const firstSegmentIsCode = pathSegments[0] && codePattern.test(pathSegments[0]);
   const secondSegmentIsCode = pathSegments[1] && codePattern.test(pathSegments[1]);
@@ -13,14 +17,39 @@ export const onRequest = defineMiddleware(async (context, next) => {
   if (firstSegmentIsCode || secondSegmentIsCode) {
     const code = (firstSegmentIsCode ? pathSegments[0] : pathSegments[1]).toLowerCase();
 
-    // Load the URL manifest to find the canonical page
-    const entries = await getCollection("urls");
-    const matchingEntry = entries.find((entry) => entry.data.code === code);
+    // Find the canonical URL for this code
+    const allEntriesForCode = entries.filter((entry) => entry.data.code === code);
+    const canonicalEntry = allEntriesForCode.find((entry) => {
+      // Canonical URLs have the format /{collection}/{slug}
+      const segments = entry.id.split("/").filter(Boolean);
+      return segments.length === 2;
+    });
 
-    if (matchingEntry) {
-      // The manifest ID is the canonical URL path (e.g., "/blog/slug")
+    if (canonicalEntry) {
       const newUrl = new URL(url);
-      newUrl.pathname = matchingEntry.id;
+      newUrl.pathname = canonicalEntry.id;
+      return context.redirect(newUrl.toString(), 301);
+    }
+  }
+
+  // Check if this exact path is in the manifest (for custom short URLs)
+  const matchingEntry = entries.find((entry) => entry.id === pathname);
+
+  if (matchingEntry) {
+    const code = matchingEntry.data.code;
+
+    // Find the canonical URL for this code
+    const allEntriesForCode = entries.filter((entry) => entry.data.code === code);
+    const canonicalEntry = allEntriesForCode.find((entry) => {
+      // Canonical URLs have the format /{collection}/{slug}
+      const segments = entry.id.split("/").filter(Boolean);
+      return segments.length === 2;
+    });
+
+    if (canonicalEntry && canonicalEntry.id !== pathname) {
+      // This is not the canonical URL, redirect to it
+      const newUrl = new URL(url);
+      newUrl.pathname = canonicalEntry.id;
       return context.redirect(newUrl.toString(), 301);
     }
   }

--- a/tests/url-manifest.test.ts
+++ b/tests/url-manifest.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { load } from "js-yaml";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface UrlManifest {
+  version: string;
+  codes: Record<string, string[]>;
+}
+
+describe("URL Manifest", () => {
+  let manifest: UrlManifest;
+  const BASE_URL = process.env.TEST_BASE_URL || "http://localhost:4321";
+
+  beforeAll(() => {
+    // Load the URL manifest
+    const manifestPath = resolve(process.cwd(), "src/content/url-manifest.yaml");
+    const manifestContent = readFileSync(manifestPath, "utf-8");
+    manifest = load(manifestContent) as UrlManifest;
+  });
+
+  it("should load the manifest successfully", () => {
+    expect(manifest).toBeDefined();
+    expect(manifest.version).toBe("1.0");
+    expect(manifest.codes).toBeDefined();
+  });
+
+  it("should have valid URL entries", () => {
+    const codes = Object.keys(manifest.codes);
+    expect(codes.length).toBeGreaterThan(0);
+
+    for (const [code, urls] of Object.entries(manifest.codes)) {
+      expect(Array.isArray(urls)).toBe(true);
+      expect(urls.length).toBeGreaterThan(0);
+
+      for (const url of urls) {
+        expect(url).toMatch(/^\//);
+      }
+    }
+  });
+
+  describe("URL resolution", () => {
+    it("should resolve all canonical URLs", async () => {
+      const allUrls = Object.values(manifest.codes).flat();
+      const uniqueUrls = [...new Set(allUrls)];
+
+      const results = await Promise.allSettled(
+        uniqueUrls.map(async (url) => {
+          const response = await fetch(`${BASE_URL}${url}`, {
+            redirect: "manual",
+          });
+
+          // Accept 200 (OK) or 3xx redirects
+          if (response.status >= 200 && response.status < 400) {
+            return { url, status: response.status, success: true };
+          }
+
+          throw new Error(`URL ${url} returned status ${response.status}: ${response.statusText}`);
+        })
+      );
+
+      const failed = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+
+      if (failed.length > 0) {
+        const errors = failed.map((r) => r.reason.message).join("\n");
+        throw new Error(`${failed.length} URLs failed to resolve:\n${errors}`);
+      }
+
+      expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    }, 30000); // 30 second timeout for all URL checks
+
+    it("should resolve all short code URLs", async () => {
+      const shortCodes = Object.keys(manifest.codes);
+
+      const results = await Promise.allSettled(
+        shortCodes.map(async (code) => {
+          const url = `/${code}`;
+          const response = await fetch(`${BASE_URL}${url}`, {
+            redirect: "manual",
+          });
+
+          // Short codes should redirect (3xx) to canonical URLs
+          if (response.status >= 300 && response.status < 400) {
+            const location = response.headers.get("location");
+            return { url, status: response.status, location, success: true };
+          }
+
+          // Or they might return 200 if middleware handles it internally
+          if (response.status === 200) {
+            return { url, status: response.status, success: true };
+          }
+
+          throw new Error(
+            `Short code ${code} returned unexpected status ${response.status}: ${response.statusText}`
+          );
+        })
+      );
+
+      const failed = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+
+      if (failed.length > 0) {
+        const errors = failed.map((r) => r.reason.message).join("\n");
+        throw new Error(`${failed.length} short codes failed to resolve:\n${errors}`);
+      }
+
+      expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+    }, 30000);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     includeSource: ["src/**/*.ts"],
+    include: ["tests/**/*.test.ts"],
   },
   define: {
     "import.meta.vitest": "undefined",


### PR DESCRIPTION
## Summary
Added comprehensive Vitest tests ensuring all URLs in the manifest resolve correctly. Includes validation for both canonical URLs and short code redirects. Fixed middleware to handle custom short URLs and normalized slug casing in manifest generation.

## Test Plan
- Run `mise run test` to execute all tests
- Tests validate 12 URLs across 10 content codes
- Middleware tested for both 5-character codes and custom URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)