### PR TITLE
Add PEX Lang project page

### DIFF
--- a/src/content/projects/pex.mdx
+++ b/src/content/projects/pex.mdx
@@ -1,0 +1,13 @@
+---
+title: PEX Lang
+description: A compact, Lisp-like programming language for data manipulation and transformation
+url: https://pex.just-be.dev
+repository: https://github.com/just-be-dev/pex
+status: active
+date: 2026-01-24
+slugs:
+  - /pex
+code: p2530
+---
+
+::readme{repo="just-be-dev/pex"}

--- a/src/content/url-manifest.yaml
+++ b/src/content/url-manifest.yaml
@@ -19,6 +19,9 @@ codes:
   p252b:
     - /projects/ccpm
     - /ccpm
+  p2530:
+    - /projects/pex
+    - /pex
   p3a89:
     - /projects/webview
     - /webview


### PR DESCRIPTION
Create a new project page for PEX Lang, a compact Lisp-like programming language for data manipulation and transformation. The page includes auto-generated code (p2530) and URL manifest mappings for canonical and short URLs.

🔗 Canonical URL: `/projects/pex`
🔗 Short URL: `/pex`
🔗 Code URL: `/p2530`

This adds the project to the portfolio alongside other active projects.