### PR TITLE
Fix wildcard service deployment configuration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "astro-site",

--- a/services/wildcard/wrangler.toml
+++ b/services/wildcard/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 # Wildcard subdomain routes
 [[routes]]
 pattern = "*.just-be.dev/*"
+zone_name = "just-be.dev"
 
 [observability]
 enabled = true


### PR DESCRIPTION
<details>

<summary>AI Summary</summary>

<br/>

Adds the required `zone_name` field to the wildcard route configuration in `services/wildcard/wrangler.toml`. This resolves a Wrangler deployment error that was preventing the wildcard service from deploying. The zone_name is necessary for custom domain routing with Cloudflare Workers.

</details>