### PR TITLE
Clean up linting issues: remove unused imports and parameters

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -140,5 +140,5 @@
     "builtin": true
   },
   "globals": {},
-  "ignorePatterns": ["dist", ".astro", "node_modules", ".wrangler", ".conductor"]
+  "ignorePatterns": ["dist", ".astro", "node_modules", ".wrangler", ".conductor", "public"]
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,5 @@
 import { defineCollection, z } from "astro:content";
-import { glob, file } from "astro/loaders";
+import { glob } from "astro/loaders";
 import { feedLoader } from "@ascorbic/feed-loader";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/src/plugins/remark-mdc-to-mdx.ts
+++ b/src/plugins/remark-mdc-to-mdx.ts
@@ -369,7 +369,7 @@ function generateImportNodes(components: Set<string>): MdxjsEsm[] {
  * The main remark plugin
  */
 export function remarkMdcToMdx() {
-  return (tree: Root, file: any) => {
+  return (tree: Root, _file: any) => {
     // Track components used in the document
     const components = new Set<string>();
 

--- a/src/utils/code.ts
+++ b/src/utils/code.ts
@@ -174,7 +174,7 @@ export class Code {
    * @param collection - The collection to get entries from
    * @returns Array of path objects with code/slug params and entry props
    */
-  static async getStaticPaths<T>(
+  static async getStaticPaths(
     collection: Awaited<ReturnType<typeof import("astro:content").getCollection<any>>>
   ) {
     return collection.map((entry) => {


### PR DESCRIPTION
<details> 

<summary>AI Summary</summary> 

<br/>

Clean up linting issues across the codebase by removing unused imports and marking unused parameters. This includes adding "public" to the oxlint ignorePatterns, removing the unused "file" import from content.config.ts, prefixing unused parameters with underscore in remark-mdc-to-mdx.ts, and removing an unused generic type parameter from getStaticPaths.

</details>