### PR TITLE
Fix publish script file append API

### DIFF
--- a/scripts/publish-package.ts
+++ b/scripts/publish-package.ts
@@ -13,6 +13,7 @@
  */
 
 import { $ } from "bun";
+import { appendFile } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
 
@@ -56,17 +57,16 @@ async function publishPackage(packageName: string, packagePath: string): Promise
 
   // Set GitHub output
   if (process.env.GITHUB_OUTPUT) {
-    await Bun.write(
+    await appendFile(
       process.env.GITHUB_OUTPUT,
-      `local_version=${localVersion}\nnpm_version=${npmVersion}\n`,
-      { flags: "a" }
+      `local_version=${localVersion}\nnpm_version=${npmVersion}\n`
     );
   }
 
   if (localVersion === npmVersion) {
     console.log(`   ⏭️  Skipped (already published)`);
     if (process.env.GITHUB_OUTPUT) {
-      await Bun.write(process.env.GITHUB_OUTPUT, `published=false\n`, { flags: "a" });
+      await appendFile(process.env.GITHUB_OUTPUT, `published=false\n`);
     }
     return {
       packageName,
@@ -91,7 +91,7 @@ async function publishPackage(packageName: string, packagePath: string): Promise
   console.log(`   ✅ Published`);
 
   if (process.env.GITHUB_OUTPUT) {
-    await Bun.write(process.env.GITHUB_OUTPUT, `published=true\n`, { flags: "a" });
+    await appendFile(process.env.GITHUB_OUTPUT, `published=true\n`);
   }
 
   return {


### PR DESCRIPTION
<details> 

<summary>AI Summary</summary> 

<br/>

Fixed the publish workflow CI failure by replacing `Bun.write()` with `appendFile` from `node:fs/promises`. `Bun.write()` doesn't support append mode, causing a TypeError when trying to write to GitHub Actions output files. The corrected approach uses Node's built-in file system API which is recommended by Bun documentation.

</details>