### PR TITLE
Fix npm package configuration and publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/just-be-dev/just-be.dev.git"
+    "url": "git+https://github.com/just-be-dev/just-be.dev.git"
   },
   "workspaces": {
     "packages": [

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -3,7 +3,9 @@
   "version": "0.2.0",
   "description": "Deploy static files to Cloudflare R2 and configure subdomain routing",
   "type": "module",
-  "bin": "./index.ts",
+  "bin": {
+    "deploy": "index.ts"
+  },
   "files": [
     "index.ts"
   ],
@@ -17,7 +19,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/justbejyk/just-be.dev.git",
+    "url": "git+https://github.com/just-be-dev/just-be.dev.git",
     "directory": "packages/deploy"
   },
   "engines": {

--- a/packages/wildcard/package.json
+++ b/packages/wildcard/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/justbejyk/just-be.dev.git",
+    "url": "git+https://github.com/just-be-dev/just-be.dev.git",
     "directory": "packages/wildcard"
   },
   "peerDependencies": {

--- a/scripts/publish-package.ts
+++ b/scripts/publish-package.ts
@@ -90,7 +90,7 @@ async function publishPackage(packageName: string, packagePath: string): Promise
   const tarball = files[0];
 
   // Publish using npm with provenance
-  await $`cd ${packagePath} && bunx npm publish ${tarball} --access public --provenance`;
+  await $`cd ${packagePath} && bunx npm publish ${tarball} --access public`;
 
   // Create GitHub release (this creates the tag and release atomically)
   const tag = `${packageName}@${localVersion}`;


### PR DESCRIPTION
<details>

<summary>AI Summary</summary>

<br/>

This PR fixes npm package configuration to improve compatibility with npm publishing:
- Updates repository URLs to use the `git+https://` prefix, which is the standard npm format
- Corrects a typo in the deploy and wildcard package repositories (`justbejyk` → `just-be-dev`)
- Changes the deploy package `bin` configuration from a string to an object to properly register the CLI command
- Removes the `--provenance` flag from npm publish for improved compatibility

</details>