### PR TITLE
(Hopefully) fix publishing by pinning node version; refactor publishing script

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ lefthook = "2.0.15"
 python = "3.14.2"
 ffmpeg = "latest"
 uv = "latest"
+node = "24.13.0"
 
 [settings]
 experimental = true

--- a/scripts/publish-package.test.ts
+++ b/scripts/publish-package.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { rm, mkdir } from "node:fs/promises";
 import { join } from "node:path";
-import {
-  getPackageInfo,
-  shouldPublish,
-  packPackage,
-  findTarball,
-  type PackageInfo,
-} from "./publish-package";
+import { getPackageInfo, shouldPublish, packPackage, findTarball } from "./publish-package";
 
 const TEST_DIR = join(import.meta.dir, "../.test-artifacts/publish-package");
 

--- a/scripts/publish-package.ts
+++ b/scripts/publish-package.ts
@@ -39,11 +39,7 @@ export interface PackageInfo {
   version: string;
 }
 
-/**
- * Main entry point for the publish script
- */
 export async function main(): Promise<void> {
-  // Parse arguments
   const [name] = process.argv.slice(2);
 
   if (!name) {


### PR DESCRIPTION
So there's a relatively big refactor of the publishing script here that I just did as a way to add more tests. The biggest impact I think this PR will have is adding `node` to the `mise.toml`. As I was scouring through the docs to figure out why the heck the publish process would be giving me errors when I had OIDC setup, I noticed a note near the top saying

> Trusted publishing requires [npm CLI](https://docs.npmjs.com/cli/v11) version 11.5.1 or later.

Well, given this is a bun project I hadn't actually added node as a dependency. That means I'm getting whatever github actions is providing implicitly. I suspect that it was lower than whatever was needed to be bundled with npm 11.5.1. 

Add comes back to [bun not supporting OIDC with `bun publish`](https://github.com/oven-sh/bun/issues/15601). 

<details> 

<summary>AI Summary</summary> 

<br/>

This PR refactors the publish-package script to improve testability and maintainability. Key changes:

- **Added Node.js 24.13.0 to mise.toml** for development environment consistency
- **Extracted reusable functions** from the main publish logic to support better testing (getPackageInfo, getNpmVersion, shouldPublish, packPackage, findTarball, publishToNpm, createGitHubRelease, writeGitHubOutputs)
- **Added comprehensive test suite** with unit tests for all core functions and edge cases
- **Cleaned up the publish-package.ts** by removing inline logic and comments, moving the entry point to a main() function

The refactored code maintains the same functionality while being more modular and testable. All functions are properly exported for use in the test suite.

</details>