### PR TITLE
Make deploy script work without wrangler.toml

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "astro-site",
@@ -33,7 +34,7 @@
     },
     "packages/deploy": {
       "name": "@just-be/deploy",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "bin": {
         "deploy": "index.ts",
       },
@@ -43,13 +44,10 @@
         "wrangler": "catalog:",
         "zod": "catalog:",
       },
-      "devDependencies": {
-        "zod-to-json-schema": "^3.24.1",
-      },
     },
     "packages/wildcard": {
       "name": "@just-be/wildcard",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "peerDependencies": {
         "zod": "^4.0.0",
       },

--- a/packages/deploy/README.md
+++ b/packages/deploy/README.md
@@ -8,6 +8,30 @@ Deploy static sites and setup routing for the wildcard subdomain service.
 - [Wrangler](https://developers.cloudflare.com/workers/wrangler/) CLI configured with Cloudflare credentials
 - A Cloudflare Workers wildcard subdomain service with R2 and KV configured
 
+## Configuration
+
+The deploy script requires access to:
+
+- **KV namespace** for routing rules (default: `6118ae3b937c4883b3c582dfef8a0c05`)
+- **R2 bucket** for static file storage (default: `content-bucket`)
+
+### Environment Variables
+
+To use different resources, set these environment variables:
+
+```bash
+export KV_NAMESPACE_ID="your-kv-namespace-id"
+export R2_BUCKET_NAME="your-bucket-name"
+bunx @just-be/deploy
+```
+
+You can find your KV namespace ID and R2 buckets by running:
+
+```bash
+wrangler kv namespace list
+wrangler r2 bucket list
+```
+
 ## Installation
 
 No installation needed! Run directly with `bunx`:
@@ -200,13 +224,14 @@ The package includes a JSON Schema (`deploy.schema.json`) for editor validation 
    - Creates a KV entry with the routing configuration
 5. **Configures** the wildcard service to route requests for each subdomain
 
-## Configuration
+## Wildcard Service Requirements
 
-The script expects your wildcard service to use:
+The script works with any wildcard service that has:
 
-- **R2 Bucket**: `content-bucket`
-- **KV Binding**: `ROUTING_RULES`
-- **Wrangler Config**: `services/wildcard/wrangler.toml`
+- **R2 Bucket**: For storing static files (default: `content-bucket`)
+- **KV Namespace**: For routing rules (default: `6118ae3b937c4883b3c582dfef8a0c05`)
+
+No local `wrangler.toml` file is required - the script accesses Cloudflare resources directly via the Wrangler CLI.
 
 ## Validation
 

--- a/packages/deploy/index.ts
+++ b/packages/deploy/index.ts
@@ -45,8 +45,8 @@ import {
   subdomain,
 } from "@just-be/wildcard";
 
-const BUCKET_NAME = "content-bucket";
-const WRANGLER_CONFIG = "services/wildcard/wrangler.toml";
+const BUCKET_NAME = process.env.R2_BUCKET_NAME || "content-bucket";
+const KV_NAMESPACE_ID = process.env.KV_NAMESPACE_ID || "6118ae3b937c4883b3c582dfef8a0c05";
 
 /**
  * Run wrangler command using bunx to ensure it resolves from package dependencies
@@ -177,7 +177,7 @@ async function uploadToR2(localPath: string, r2Key: string): Promise<boolean> {
  */
 async function validateKVAccess(): Promise<boolean> {
   try {
-    await wrangler`kv key list --binding ROUTING_RULES --config ${WRANGLER_CONFIG}`.quiet();
+    await wrangler`kv key list --namespace-id ${KV_NAMESPACE_ID}`.quiet();
     return true;
   } catch {
     return false;
@@ -213,7 +213,7 @@ function sanitizeBranchName(branch: string): string {
  */
 async function createKVEntry(subdomain: string, routeConfig: RouteConfig): Promise<void> {
   const configJson = JSON.stringify(routeConfig);
-  await wrangler`kv key put --binding ROUTING_RULES ${subdomain} ${configJson} --config ${WRANGLER_CONFIG}`;
+  await wrangler`kv key put --namespace-id ${KV_NAMESPACE_ID} ${subdomain} ${configJson}`;
 }
 
 /**

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-be/deploy",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Deploy static sites to Cloudflare R2 with subdomain routing",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Tried to setup a deployment in another repo and it was failing due to not being auth'd for KV. 

<details>

<summary>AI Summary</summary>

<br/>

The deploy script previously required a relative path to `services/wildcard/wrangler.toml`, which only worked when run from the monaco workspace. This change removes that dependency by using Cloudflare resource IDs directly (KV namespace ID and R2 bucket name) configured via environment variables with sensible defaults. The script now works from any project as long as the user is authenticated with wrangler. Version bumped to 0.4.0 to reflect this new feature.

</details>