### PR TITLE
Add --remote flag to kv and r2 wrangler commands

### DIFF
--- a/packages/deploy/index.ts
+++ b/packages/deploy/index.ts
@@ -179,7 +179,15 @@ async function findFiles(dir: string): Promise<string[]> {
  */
 async function uploadToR2(localPath: string, r2Key: string): Promise<boolean> {
   try {
-    await wrangler("r2", "object", "put", `${BUCKET_NAME}/${r2Key}`, "--file", localPath);
+    await wrangler(
+      "r2",
+      "object",
+      "put",
+      `${BUCKET_NAME}/${r2Key}`,
+      "--file",
+      localPath,
+      "--remote"
+    );
     return true;
   } catch (error) {
     if (DEBUG) {
@@ -219,7 +227,7 @@ async function validateWranglerAuth(): Promise<boolean> {
  */
 async function validateKVAccess(): Promise<boolean> {
   try {
-    await wrangler("kv", "key", "list", "--namespace-id", KV_NAMESPACE_ID).quiet();
+    await wrangler("kv", "key", "list", "--namespace-id", KV_NAMESPACE_ID, "--remote").quiet();
     return true;
   } catch (error) {
     if (DEBUG) {
@@ -270,7 +278,16 @@ function sanitizeBranchName(branch: string): string {
  */
 async function createKVEntry(subdomain: string, routeConfig: RouteConfig): Promise<void> {
   const configJson = JSON.stringify(routeConfig);
-  await wrangler("kv", "key", "put", "--namespace-id", KV_NAMESPACE_ID, subdomain, configJson);
+  await wrangler(
+    "kv",
+    "key",
+    "put",
+    "--namespace-id",
+    KV_NAMESPACE_ID,
+    subdomain,
+    configJson,
+    "--remote"
+  );
 }
 
 /**

--- a/packages/deploy/package.json
+++ b/packages/deploy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@just-be/deploy",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Deploy static sites to Cloudflare R2 with subdomain routing",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Left this out, but this is needed to make sure it updates the actual deployed state instead of the local miniflare state. 

<details>

<summary>AI Summary</summary>

<br/>

This PR adds the `--remote` flag to all kv and r2 wrangler commands in the deploy script to ensure operations target cloud resources instead of the local development environment. The version is also bumped from 0.8.0 to 0.8.1.

</details>