### PR TITLE
Add webview-cli project

### DIFF
--- a/src/content/projects/webview-cli.mdx
+++ b/src/content/projects/webview-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: webview-cli
-description: A webview CLI: render HTML, get back JSON
+description: "A webview CLI: render HTML, get back JSON"
 status: active
 date: 2026-06-05
 url: https://github.com/just-be-dev/webview-cli

--- a/src/content/projects/webview-cli.mdx
+++ b/src/content/projects/webview-cli.mdx
@@ -1,0 +1,11 @@
+---
+title: webview-cli
+description: A webview CLI: render HTML, get back JSON
+status: active
+date: 2026-06-05
+url: https://github.com/just-be-dev/webview-cli
+repository: https://github.com/just-be-dev/webview-cli
+code: p25b4
+---
+
+::readme{repo="just-be-dev/webview-cli"}

--- a/src/content/url-manifest.yaml
+++ b/src/content/url-manifest.yaml
@@ -27,6 +27,8 @@ codes:
   p2530:
     - /projects/pex
     - /pex
+  p25b4:
+    - /projects/webview-cli
   p3a89:
     - /projects/webview
     - /webview

--- a/src/loaders/github-readme.ts
+++ b/src/loaders/github-readme.ts
@@ -165,9 +165,11 @@ export function githubReadmeLoader(): LiveLoader<ReadmeData, EntryFilter, Collec
         const renderer = createRenderer(owner, repo, branch);
 
         // Parse markdown to HTML using marked
+        // Match GitHub's README rendering: single newlines within a paragraph
+        // collapse to spaces rather than becoming hard <br> breaks
         marked.setOptions({
           gfm: true,
-          breaks: true,
+          breaks: false,
           renderer: renderer,
         });
         const renderedHtml = await marked.parse(markdownWithoutH1);

--- a/src/loaders/github-readme.ts
+++ b/src/loaders/github-readme.ts
@@ -153,8 +153,10 @@ export function githubReadmeLoader(): LiveLoader<ReadmeData, EntryFilter, Collec
 
         const readmeData = await readmeResponse.json();
 
-        // Decode base64 content
-        const readmeMarkdown = atob(readmeData.content);
+        // Decode base64 content, reinterpreting the raw bytes as UTF-8 so
+        // multibyte characters (em dashes, smart quotes, etc.) render correctly
+        const bytes = Uint8Array.from(atob(readmeData.content), (c) => c.charCodeAt(0));
+        const readmeMarkdown = new TextDecoder("utf-8").decode(bytes);
 
         // Strip the first H1 heading
         const markdownWithoutH1 = stripFirstH1(readmeMarkdown);


### PR DESCRIPTION
Adds the webview-cli project (a CLI that renders HTML and returns JSON) to the projects collection. The page pulls in the repo README at build time via the `::readme` component, matching the existing webview and jexl projects.