### PR TITLE
Fix Lefthook postinstall idempotency

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,7 @@ experimental = true
 pin = true
 
 [hooks]
-postinstall = ["bun install", "lefthook install"]
+postinstall = ["bun install", "lefthook check-install || lefthook install"]
 
 [env]
 _.path = "node_modules/.bin"


### PR DESCRIPTION
## Summary
- Gate the mise postinstall Lefthook setup with `lefthook check-install`.
- Avoid rerunning `lefthook install` when GitButler already has Lefthook installed as the user pre-commit hook.

## Verification
- `mise install`
- `bun run build`